### PR TITLE
Provide light and dark text themes

### DIFF
--- a/lib/utils/theme/custom_themes/text_theme.dart
+++ b/lib/utils/theme/custom_themes/text_theme.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+class MyTextTheme {
+  static TextTheme lightTextTheme = TextTheme(
+    headlineLarge: const TextStyle().copyWith(
+        fontSize: 32.0, fontWeight: FontWeight.bold, color: Colors.black),
+    headlineMedium: const TextStyle().copyWith(
+        fontSize: 24.0, fontWeight: FontWeight.w600, color: Colors.black),
+    headlineSmall: const TextStyle().copyWith(
+        fontSize: 18.0, fontWeight: FontWeight.w600, color: Colors.black),
+    titleLarge: const TextStyle().copyWith(
+        fontSize: 16.0, fontWeight: FontWeight.w600, color: Colors.black),
+    titleMedium: const TextStyle().copyWith(
+        fontSize: 16.0, fontWeight: FontWeight.w500, color: Colors.black),
+    titleSmall: const TextStyle().copyWith(
+        fontSize: 16.0, fontWeight: FontWeight.w400, color: Colors.black),
+    bodyLarge: const TextStyle().copyWith(
+        fontSize: 14.0, fontWeight: FontWeight.w500, color: Colors.black),
+    bodyMedium: const TextStyle().copyWith(
+        fontSize: 14.0, fontWeight: FontWeight.normal, color: Colors.black),
+    bodySmall: const TextStyle().copyWith(
+        fontSize: 14.0,
+        fontWeight: FontWeight.w500,
+        color: Colors.black.withOpacity(0.5)),
+    labelLarge: const TextStyle().copyWith(
+        fontSize: 12.0, fontWeight: FontWeight.normal, color: Colors.black),
+    labelMedium: const TextStyle().copyWith(
+        fontSize: 12.0,
+        fontWeight: FontWeight.normal,
+        color: Colors.black.withOpacity(0.5)),
+  );
+
+  static TextTheme darkTextTheme = TextTheme(
+    headlineLarge: const TextStyle().copyWith(
+        fontSize: 32.0, fontWeight: FontWeight.bold, color: Colors.white),
+    headlineMedium: const TextStyle().copyWith(
+        fontSize: 24.0, fontWeight: FontWeight.w600, color: Colors.white),
+    headlineSmall: const TextStyle().copyWith(
+        fontSize: 18.0, fontWeight: FontWeight.w600, color: Colors.white),
+    titleLarge: const TextStyle().copyWith(
+        fontSize: 16.0, fontWeight: FontWeight.w600, color: Colors.white),
+    titleMedium: const TextStyle().copyWith(
+        fontSize: 16.0, fontWeight: FontWeight.w500, color: Colors.white),
+    titleSmall: const TextStyle().copyWith(
+        fontSize: 16.0, fontWeight: FontWeight.w400, color: Colors.white),
+    bodyLarge: const TextStyle().copyWith(
+        fontSize: 14.0, fontWeight: FontWeight.w500, color: Colors.white),
+    bodyMedium: const TextStyle().copyWith(
+        fontSize: 14.0, fontWeight: FontWeight.normal, color: Colors.white),
+    bodySmall: const TextStyle().copyWith(
+        fontSize: 14.0,
+        fontWeight: FontWeight.w500,
+        color: Colors.white.withOpacity(0.5)),
+    labelLarge: const TextStyle().copyWith(
+        fontSize: 12.0, fontWeight: FontWeight.normal, color: Colors.white),
+    labelMedium: const TextStyle().copyWith(
+        fontSize: 12.0,
+        fontWeight: FontWeight.normal,
+        color: Colors.white.withOpacity(0.5)),
+  );
+}


### PR DESCRIPTION
Adding a new file `text_theme.dart` that defines custom text themes for both light and dark modes in a Flutter app. The file includes specific styles for various text components like headline, title, body, and label with different sizes and weights.

---

