### PR TITLE
Add Light and Dark Chip Themes to MyAppTheme

### DIFF
--- a/lib/utils/theme/custom_themes/chip_theme.dart
+++ b/lib/utils/theme/custom_themes/chip_theme.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class MyChipTheme {
+  static ChipThemeData lightChipTheme = ChipThemeData(
+    disabledColor: Colors.grey.withOpacity(0.4),
+    labelStyle: const TextStyle(color: Colors.black),
+    selectedColor: Colors.deepPurple,
+    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+    checkmarkColor: Colors.white,
+  );
+
+  static ChipThemeData darkChipTheme = const ChipThemeData(
+    disabledColor: Colors.grey,
+    labelStyle: TextStyle(color: Colors.white),
+    selectedColor: Colors.deepPurple,
+    padding: EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+    checkmarkColor: Colors.white,
+  );
+}

--- a/lib/utils/theme/theme.dart
+++ b/lib/utils/theme/theme.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:mystore/utils/theme/custom_themes/appbar_theme.dart';
 import 'package:mystore/utils/theme/custom_themes/bottom_sheet_theme.dart';
 import 'package:mystore/utils/theme/custom_themes/checkbox_theme.dart';
+import 'package:mystore/utils/theme/custom_themes/chip_theme.dart';
 import 'package:mystore/utils/theme/custom_themes/elevated_button_theme.dart';
 import 'package:mystore/utils/theme/custom_themes/text_theme.dart';
 
@@ -17,6 +18,7 @@ class MyAppTheme {
     appBarTheme: MyAppBarTheme.lightAppBarTheme,
     bottomSheetTheme: MyBottomSheetTheme.lightBottomSheetTheme,
     checkboxTheme: MyCheckboxTheme.lightCheckboxTheme,
+    chipTheme: MyChipTheme.lightChipTheme,
   );
 
   static ThemeData darkTheme = ThemeData(
@@ -30,5 +32,6 @@ class MyAppTheme {
     appBarTheme: MyAppBarTheme.darkAppBarTheme,
     bottomSheetTheme: MyBottomSheetTheme.darkBottomSheetTheme,
     checkboxTheme: MyCheckboxTheme.darkCheckboxTheme,
+    chipTheme: MyChipTheme.darkChipTheme,
   );
 }


### PR DESCRIPTION
This PR introduces a custom ChipTheme to the MyAppTheme in both light and dark themes. It creates a new file `chip_theme.dart` containing ChipThemeData configurations and updates `theme.dart` to include these themes.

---

