### PR TITLE
Add custom text field themes

### DIFF
--- a/lib/utils/theme/custom_themes/text_field_theme.dart
+++ b/lib/utils/theme/custom_themes/text_field_theme.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+class MyTextFormFieldTheme {
+  static InputDecorationTheme lightInputDecorationTheme = InputDecorationTheme(
+    errorMaxLines: 3,
+    prefixIconColor: Colors.grey,
+    suffixIconColor: Colors.grey,
+    labelStyle: const TextStyle().copyWith(fontSize: 14, color: Colors.black),
+    hintStyle: const TextStyle().copyWith(fontSize: 14, color: Colors.black),
+    errorStyle: const TextStyle().copyWith(fontStyle: FontStyle.normal),
+    floatingLabelStyle:
+        const TextStyle().copyWith(color: Colors.black.withOpacity(0.8)),
+    border: const OutlineInputBorder().copyWith(
+      borderRadius: BorderRadius.circular(14),
+      borderSide: const BorderSide(width: 1, color: Colors.grey),
+    ),
+    enabledBorder: const OutlineInputBorder().copyWith(
+      borderRadius: BorderRadius.circular(14),
+      borderSide: const BorderSide(width: 1, color: Colors.grey),
+    ),
+    focusedBorder: const OutlineInputBorder().copyWith(
+      borderRadius: BorderRadius.circular(14),
+      borderSide: const BorderSide(width: 1, color: Colors.black12),
+    ),
+    errorBorder: const OutlineInputBorder().copyWith(
+      borderRadius: BorderRadius.circular(14),
+      borderSide: const BorderSide(width: 1, color: Colors.red),
+    ),
+    focusedErrorBorder: const OutlineInputBorder().copyWith(
+      borderRadius: BorderRadius.circular(14),
+      borderSide: const BorderSide(width: 2, color: Colors.orange),
+    ),
+  );
+
+  static InputDecorationTheme darkInputDecorationTheme = InputDecorationTheme(
+    errorMaxLines: 2,
+    prefixIconColor: Colors.grey,
+    suffixIconColor: Colors.grey,
+    labelStyle: const TextStyle().copyWith(fontSize: 14, color: Colors.white),
+    hintStyle: const TextStyle().copyWith(fontSize: 14, color: Colors.white),
+    floatingLabelStyle:
+        const TextStyle().copyWith(color: Colors.white.withOpacity(0.8)),
+    border: const OutlineInputBorder().copyWith(
+      borderRadius: BorderRadius.circular(14),
+      borderSide: const BorderSide(width: 1, color: Colors.grey),
+    ),
+    enabledBorder: const OutlineInputBorder().copyWith(
+      borderRadius: BorderRadius.circular(14),
+      borderSide: const BorderSide(width: 1, color: Colors.grey),
+    ),
+    focusedBorder: const OutlineInputBorder().copyWith(
+      borderRadius: BorderRadius.circular(14),
+      borderSide: const BorderSide(width: 1, color: Colors.white),
+    ),
+    errorBorder: const OutlineInputBorder().copyWith(
+      borderRadius: BorderRadius.circular(14),
+      borderSide: const BorderSide(width: 1, color: Colors.red),
+    ),
+    focusedErrorBorder: const OutlineInputBorder().copyWith(
+      borderRadius: BorderRadius.circular(14),
+      borderSide: const BorderSide(width: 2, color: Colors.orange),
+    ),
+  );
+}

--- a/lib/utils/theme/theme.dart
+++ b/lib/utils/theme/theme.dart
@@ -5,6 +5,7 @@ import 'package:mystore/utils/theme/custom_themes/checkbox_theme.dart';
 import 'package:mystore/utils/theme/custom_themes/chip_theme.dart';
 import 'package:mystore/utils/theme/custom_themes/elevated_button_theme.dart';
 import 'package:mystore/utils/theme/custom_themes/outlined_button_theme.dart';
+import 'package:mystore/utils/theme/custom_themes/text_field_theme.dart';
 import 'package:mystore/utils/theme/custom_themes/text_theme.dart';
 
 class MyAppTheme {
@@ -13,14 +14,15 @@ class MyAppTheme {
     fontFamily: 'Poppins',
     brightness: Brightness.light,
     primaryColor: Colors.deepPurple,
-    scaffoldBackgroundColor: Colors.white,
     textTheme: MyTextTheme.lightTextTheme,
+    chipTheme: MyChipTheme.lightChipTheme,
+    scaffoldBackgroundColor: Colors.white,
+    appBarTheme: MyAppBarTheme.lightAppBarTheme,
+    checkboxTheme: MyCheckboxTheme.lightCheckboxTheme,
+    bottomSheetTheme: MyBottomSheetTheme.lightBottomSheetTheme,
     elevatedButtonTheme: MyELevatedButtonTheme.lightElevatedButtonTheme,
     outlinedButtonTheme: MyOutlinedButtonTheme.lightOutlinedButtonTheme,
-    appBarTheme: MyAppBarTheme.lightAppBarTheme,
-    bottomSheetTheme: MyBottomSheetTheme.lightBottomSheetTheme,
-    checkboxTheme: MyCheckboxTheme.lightCheckboxTheme,
-    chipTheme: MyChipTheme.lightChipTheme,
+    inputDecorationTheme: MyTextFormFieldTheme.lightInputDecorationTheme,
   );
 
   static ThemeData darkTheme = ThemeData(
@@ -28,13 +30,14 @@ class MyAppTheme {
     fontFamily: 'Poppins',
     brightness: Brightness.dark,
     primaryColor: Colors.deepPurple,
-    scaffoldBackgroundColor: Colors.black,
     textTheme: MyTextTheme.darkTextTheme,
+    chipTheme: MyChipTheme.darkChipTheme,
+    scaffoldBackgroundColor: Colors.black,
+    appBarTheme: MyAppBarTheme.darkAppBarTheme,
+    checkboxTheme: MyCheckboxTheme.darkCheckboxTheme,
+    bottomSheetTheme: MyBottomSheetTheme.darkBottomSheetTheme,
     elevatedButtonTheme: MyELevatedButtonTheme.darkElevatedButtonTheme,
     outlinedButtonTheme: MyOutlinedButtonTheme.darkOutlinedButtonTheme,
-    appBarTheme: MyAppBarTheme.darkAppBarTheme,
-    bottomSheetTheme: MyBottomSheetTheme.darkBottomSheetTheme,
-    checkboxTheme: MyCheckboxTheme.darkCheckboxTheme,
-    chipTheme: MyChipTheme.darkChipTheme,
+    inputDecorationTheme: MyTextFormFieldTheme.darkInputDecorationTheme,
   );
 }


### PR DESCRIPTION
This pull request introduces custom `InputDecorationTheme` for both light and dark themes. The themes define the styles for various states of text fields, including their borders, label styles, error styles, and colors. The new themes are also integrated into the main theme data for both light and dark modes in `theme.dart`. This change aims to ensure a consistent look and feel for text inputs across the application.

---

