### PR TITLE
Configuring go_router

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mystore/utils/navigation/go_routes.dart';
 import 'package:mystore/utils/theme/theme.dart';
 
 class App extends StatelessWidget {
@@ -6,15 +7,12 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
+      debugShowCheckedModeBanner: false,
+      routerConfig: AppRoute.routes,
       themeMode: ThemeMode.system,
       theme: MyAppTheme.lightTheme,
       darkTheme: MyAppTheme.darkTheme,
-      home: const Scaffold(
-        body: Center(
-          child: Text('Hello World!'),
-        ),
-      ),
     );
   }
 }

--- a/lib/utils/navigation/go_routes.dart
+++ b/lib/utils/navigation/go_routes.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mystore/features/authentication/screens/onboarding.dart';
+
+enum MyRoutes {
+  onboarding,
+}
+
+class AppRoute {
+  static GoRouter get routes => _routes;
+
+  static BuildContext? get globalContext => _rootNavigatorKey.currentContext;
+
+  static GlobalKey<NavigatorState> get rootNavigatorKey => _rootNavigatorKey;
+  static GlobalKey<NavigatorState> get shellNavigatorKey => _shellNavigatorKey;
+
+  static final _rootNavigatorKey = GlobalKey<NavigatorState>();
+  static final _shellNavigatorKey = GlobalKey<NavigatorState>();
+
+  static const String _onboarding = '/onboarding';
+
+  static final _routes = GoRouter(
+    navigatorKey: _rootNavigatorKey,
+    initialLocation: _onboarding,
+    routes: [
+      GoRoute(
+        path: _onboarding,
+        name: MyRoutes.onboarding.name,
+        builder: (context, state) => const OnboardingScreen(),
+      ),
+    ],
+  );
+}


### PR DESCRIPTION
### Summary

Switched from `MaterialApp` to `MaterialApp.router` and integrated GoRouter for route management.

### What changed?

- Updated the app entry point from `MaterialApp` to `MaterialApp.router`.
- Added `go_routes.dart` for route configurations using `GoRouter`.

### How to test?

1. Run the application.
2. Verify that the onboarding screen is displayed as the initial route.
3. Navigate through the application to ensure that routing works as expected.

### Why make this change?

To enhance the application's navigation capabilities with a more structured and manageable routing system provided by `GoRouter`. This will help in managing complex navigation flows more efficiently.

---

