### PR TITLE
Add dependencies

### DIFF
--- a/.dart_tool/package_config.json
+++ b/.dart_tool/package_config.json
@@ -176,6 +176,12 @@
       "languageVersion": "2.18"
     },
     {
+      "name": "equatable",
+      "rootUri": "file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/equatable-2.0.5",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
       "name": "fake_async",
       "rootUri": "file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/fake_async-1.3.1",
       "packageUri": "lib/",
@@ -728,7 +734,7 @@
       "languageVersion": "3.4"
     }
   ],
-  "generated": "2024-07-09T08:12:23.207275Z",
+  "generated": "2024-07-09T19:24:01.334650Z",
   "generator": "pub",
   "generatorVersion": "3.4.3",
   "flutterRoot": "file:///D:/flutter_windows_3.13.7-stable/flutter",

--- a/.dart_tool/package_config_subset
+++ b/.dart_tool/package_config_subset
@@ -114,6 +114,10 @@ dio_web_adapter
 2.18
 file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/dio_web_adapter-1.0.1/
 file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/dio_web_adapter-1.0.1/lib/
+equatable
+2.12
+file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/equatable-2.0.5/
+file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/equatable-2.0.5/lib/
 fake_async
 2.12
 file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/fake_async-1.3.1/

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -233,6 +233,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   intl: ^0.19.0
   logger: ^2.3.0
   get_it: ^7.7.0
+  equatable: ^2.0.5
   go_router: ^14.2.0
   injectable: ^2.4.2
   url_launcher: ^6.3.0


### PR DESCRIPTION
### Summary

Add the `equatable` dependency to the project.

### What changed?

- Added `equatable` dependency version `2.0.5` to `pubspec.yaml`
- Updated `pubspec.lock` to include `equatable` 2.0.5
- Updated `.dart_tool/package_config.json` to include `equatable`
- Updated `.dart_tool/package_config_subset` to include `equatable`

### How to test?

Ensure that the project compiles successfully.

### Why make this change?

`equatable` simplifies value comparison by overriding the default `==` operator and `hashCode`, making it easier to work with immutable data structures.

---

![photo_4929587906016816185_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/6c88c6ec-0937-46a1-aa56-31ff639fb115.jpg)

