### PR TITLE
Login Footer

### DIFF
--- a/lib/features/authentication/screens/login/login.dart
+++ b/lib/features/authentication/screens/login/login.dart
@@ -28,7 +28,7 @@ class LoginScreen extends StatelessWidget {
                   Image(
                     height: 150,
                     image: AssetImage(
-                      dark ? MyImages.loginImageDark : MyImages.loginImageLight,
+                      dark ? MyImages.darkAppLogo : MyImages.lightAppLogo,
                     ),
                   ),
                   Text(
@@ -141,6 +141,41 @@ class LoginScreen extends StatelessWidget {
                       indent: 5,
                       endIndent: 60,
                       thickness: 0.5,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: MySizes.spaceBtwSections),
+
+              // Footer
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Container(
+                    decoration: BoxDecoration(
+                        border: Border.all(color: MyColors.grey),
+                        borderRadius: BorderRadius.circular(100)),
+                    child: IconButton(
+                      onPressed: () {},
+                      icon: const Image(
+                        image: AssetImage(MyImages.google),
+                        width: MySizes.iconMd,
+                        height: MySizes.iconMd,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: MySizes.spaceBtwItems),
+                  Container(
+                    decoration: BoxDecoration(
+                        border: Border.all(color: MyColors.grey),
+                        borderRadius: BorderRadius.circular(100)),
+                    child: IconButton(
+                      onPressed: () {},
+                      icon: const Image(
+                        image: AssetImage(MyImages.facebook),
+                        width: MySizes.iconMd,
+                        height: MySizes.iconMd,
+                      ),
                     ),
                   ),
                 ],


### PR DESCRIPTION
### Summary

Added Google and Facebook login buttons to the login screen and updated the logo images based on the theme.

### What changed?

1. Updated the logo images displayed based on the dark or light theme from `MyImages.loginImageDark` and `MyImages.loginImageLight` to `MyImages.darkAppLogo` and `MyImages.lightAppLogo` respectively.
2. Added social login buttons for Google and Facebook at the bottom of the login screen, with appropriate styling.

### How to test?

1. Run the application and navigate to the login screen.
2. Verify that the logo images change based on the theme (dark or light).
3. Check that the Google and Facebook login buttons are displayed at the bottom of the screen.

### Why make this change?

To provide users with more authentication options and to update the visuals of the login screen.

---

![photo_4951934255785684588_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/55d84cda-ad2c-40c1-8f1b-d5aae96eb88b.jpg)

