### PR TITLE
Add Login route

### DIFF
--- a/lib/features/authentication/bloc/onboarding_controller/onboarding_controller_cubit.dart
+++ b/lib/features/authentication/bloc/onboarding_controller/onboarding_controller_cubit.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mystore/utils/navigation/go_routes.dart';
 
 part 'onboarding_controller_state.dart';
 
@@ -17,7 +19,7 @@ class OnboardingControllerCubit extends Cubit<OnboardingControllerState> {
 
   void nextPage() {
     if (state.currentPageIndex == 2) {
-      //TODO: Navigate to the login screen
+      AppRoute.routes.goNamed(MyRoutes.login.name);
     } else {
       int page = state.currentPageIndex + 1;
       pageController.jumpToPage(page);

--- a/lib/utils/navigation/go_routes.dart
+++ b/lib/utils/navigation/go_routes.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mystore/features/authentication/screens/login/login.dart';
 import 'package:mystore/features/authentication/screens/onboarding/onboarding.dart';
 
 enum MyRoutes {
   onboarding,
+  login,
 }
 
 class AppRoute {
@@ -18,6 +20,7 @@ class AppRoute {
   static final _shellNavigatorKey = GlobalKey<NavigatorState>();
 
   static const String _onboarding = '/onboarding';
+  static const String _login = '/login';
 
   static final _routes = GoRouter(
     navigatorKey: _rootNavigatorKey,
@@ -27,6 +30,11 @@ class AppRoute {
         path: _onboarding,
         name: MyRoutes.onboarding.name,
         builder: (context, state) => const OnboardingScreen(),
+      ),
+      GoRoute(
+        path: _login,
+        name: MyRoutes.login.name,
+        builder: (context, state) => const LoginScreen(),
       ),
     ],
   );


### PR DESCRIPTION
### Summary

Added navigation to the login screen from the onboarding flow using go_router.

### What changed?

- Updated `OnboardingControllerCubit` to navigate to the login screen when the onboarding is complete.
- Modified `go_routes.dart` to include the login route and its corresponding `LoginScreen`.

### How to test?

1. Complete the onboarding process in the app.
2. Ensure that you are navigated to the login screen.

### Why make this change?

This change ensures that users are directed to the login screen after completing the onboarding flow, improving the overall user experience.

---

