### PR TITLE
Signup Route

### DIFF
--- a/lib/features/authentication/screens/login/widgets/login_form.dart
+++ b/lib/features/authentication/screens/login/widgets/login_form.dart
@@ -1,8 +1,11 @@
-
 import 'package:flutter/material.dart';
+
+import 'package:go_router/go_router.dart';
 import 'package:iconsax/iconsax.dart';
+
 import 'package:mystore/utils/constants/sizes.dart';
 import 'package:mystore/utils/constants/text_strings.dart';
+import 'package:mystore/utils/navigation/go_routes.dart';
 
 class LoginForm extends StatelessWidget {
   const LoginForm({
@@ -74,7 +77,9 @@ class LoginForm extends StatelessWidget {
             SizedBox(
               width: double.infinity,
               child: OutlinedButton(
-                onPressed: () {},
+                onPressed: () {
+                  context.goNamed(MyRoutes.signup.name);
+                },
                 child: const Text(MyTexts.createAccount),
               ),
             ),

--- a/lib/utils/navigation/go_routes.dart
+++ b/lib/utils/navigation/go_routes.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mystore/features/authentication/screens/login/login.dart';
 import 'package:mystore/features/authentication/screens/onboarding/onboarding.dart';
+import 'package:mystore/features/authentication/screens/signup/signup.dart';
 
 enum MyRoutes {
   onboarding,
   login,
+  signup,
 }
 
 class AppRoute {
@@ -21,6 +23,7 @@ class AppRoute {
 
   static const String _onboarding = '/onboarding';
   static const String _login = '/login';
+  static const String _signup = 'signup';
 
   static final _routes = GoRouter(
     navigatorKey: _rootNavigatorKey,
@@ -35,6 +38,13 @@ class AppRoute {
         path: _login,
         name: MyRoutes.login.name,
         builder: (context, state) => const LoginScreen(),
+        routes: [
+          GoRoute(
+            path: _signup,
+            name: MyRoutes.signup.name,
+            builder: (context, state) => const SignupScreen(),
+          ),
+        ],
       ),
     ],
   );


### PR DESCRIPTION
### Summary

Add routes for signup and create account navigation in login form.

### What changed?

- Added `signup` route in `MyRoutes` enum.
- Updated `_routes` in `AppRoute` to include the signup route.
- Modified `LoginForm` widget to navigate to signup screen when 'Create Account' button is pressed.

### How to test?

1. Go to the login screen.
2. Press the 'Create Account' button.
3. Verify that the navigation takes you to the signup screen.

### Why make this change?

This change enables users to navigate to the signup screen from the login form, improving the user experience.

---

