### PR TITLE
Singup Button

### DIFF
--- a/lib/features/authentication/screens/signup/signup.dart
+++ b/lib/features/authentication/screens/signup/signup.dart
@@ -154,6 +154,16 @@ class SignupScreen extends StatelessWidget {
                         ),
                       ],
                     ),
+                    const SizedBox(height: MySizes.spaceBtwSections),
+
+                    /// Sign Up Button
+                    SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        onPressed: () {},
+                        child: const Text(MyTexts.createAccount),
+                      ),
+                    ),
                   ],
                 ),
               ),


### PR DESCRIPTION
### Summary

Add a sign-up button to the SignUp screen in the authentication feature.

### What changed?
Added a new elevated button to the signup screen. The button spans the full width and is labeled 'Create Account'.

### How to test?
Verify the presence of the 'Create Account' button on the signup screen. Ensure it spans the full width and that the text is correctly displayed as 'Create Account'.

### Why make this change?
This change was made to provide users with a clear and accessible way to create a new account directly from the signup screen.

---

![photo_4951934255785684597_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/deaf0cfd-8e1d-49c7-9072-c1ef3bee5f18.jpg)

