### PR TITLE
Verify Email Sreen Route

### DIFF
--- a/lib/features/authentication/screens/signup/verify_email.dart
+++ b/lib/features/authentication/screens/signup/verify_email.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:mystore/utils/constants/sizes.dart';
+
+class VerifyEmailScreen extends StatelessWidget {
+  const VerifyEmailScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: EdgeInsets.all(MySizes.defaultSpace),
+          child: Column(
+            children: [
+              /// Image
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/authentication/screens/signup/widgets/signup_form.dart
+++ b/lib/features/authentication/screens/signup/widgets/signup_form.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:iconsax/iconsax.dart';
 
 import 'package:mystore/features/authentication/screens/signup/widgets/terms_conditions_checkbox.dart';
 import 'package:mystore/utils/constants/sizes.dart';
 import 'package:mystore/utils/constants/text_strings.dart';
+import 'package:mystore/utils/navigation/go_routes.dart';
 
 class SignupForm extends StatelessWidget {
   const SignupForm({
@@ -87,7 +89,9 @@ class SignupForm extends StatelessWidget {
           SizedBox(
             width: double.infinity,
             child: ElevatedButton(
-              onPressed: () {},
+              onPressed: () {
+                context.goNamed(MyRoutes.verifyEmail.name);
+              },
               child: const Text(MyTexts.createAccount),
             ),
           ),

--- a/lib/utils/navigation/go_routes.dart
+++ b/lib/utils/navigation/go_routes.dart
@@ -3,11 +3,13 @@ import 'package:go_router/go_router.dart';
 import 'package:mystore/features/authentication/screens/login/login.dart';
 import 'package:mystore/features/authentication/screens/onboarding/onboarding.dart';
 import 'package:mystore/features/authentication/screens/signup/signup.dart';
+import 'package:mystore/features/authentication/screens/signup/verify_email.dart';
 
 enum MyRoutes {
   onboarding,
   login,
   signup,
+  verifyEmail,
 }
 
 class AppRoute {
@@ -24,6 +26,7 @@ class AppRoute {
   static const String _onboarding = '/onboarding';
   static const String _login = '/login';
   static const String _signup = 'signup';
+  static const String _verifyEmail = 'verify_email';
 
   static final _routes = GoRouter(
     navigatorKey: _rootNavigatorKey,
@@ -43,6 +46,13 @@ class AppRoute {
             path: _signup,
             name: MyRoutes.signup.name,
             builder: (context, state) => const SignupScreen(),
+            routes: [
+              GoRoute(
+                path: _verifyEmail,
+                name: MyRoutes.verifyEmail.name,
+                builder: (context, state) => const VerifyEmailScreen(),
+              ),
+            ],
           ),
         ],
       ),


### PR DESCRIPTION
### Summary

Add email verification flow within SignUp process.

### What changed?

- Added `VerifyEmailScreen` to handle email verification.
- Modified `SignupForm` to navigate to `VerifyEmailScreen` upon form submission.
- Updated `go_routes` to include `verifyEmail` route.

### How to test?

1. Navigate to the SignUp screen.
2. Fill the signup form and submit.
3. Verify if the app navigates to the email verification screen.

### Why make this change?

To enhance the signup process by adding an email verification step, ensuring that users verify their email addresses before accessing the application.

---

