### PR TITLE
Verify Email Appbar

### DIFF
--- a/lib/features/authentication/screens/signup/verify_email.dart
+++ b/lib/features/authentication/screens/signup/verify_email.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mystore/utils/constants/sizes.dart';
 
 class VerifyEmailScreen extends StatelessWidget {
@@ -7,6 +9,17 @@ class VerifyEmailScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(
+        automaticallyImplyLeading: false,
+        actions: [
+          IconButton(
+            onPressed: () {
+              context.pop();
+            },
+            icon: const Icon(CupertinoIcons.clear),
+          ),
+        ],
+      ),
       body: SingleChildScrollView(
         child: Padding(
           padding: EdgeInsets.all(MySizes.defaultSpace),


### PR DESCRIPTION
### Summary
Added an AppBar with a Close button to the VerifyEmailScreen.

### What changed?
- Imported `package:flutter/cupertino.dart` and `package:go_router/go_router.dart`.
- Added an AppBar with a Close button (CupertinoIcons.clear) to the VerifyEmailScreen.
- The Close button pops the current screen from the navigation stack.

### How to test?
1. Navigate to the VerifyEmailScreen in the app.
2. Verify that an AppBar with a Close button is displayed.
3. Tap the Close button to ensure it pops the current screen.

### Why make this change?
To provide users with a clear and accessible way to close the VerifyEmailScreen.

---

![photo_4951934255785684590_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/ad1f4105-2301-4aa6-8699-19eeaf1be3eb.jpg)

