### PR TITLE
Verify Email Buttons

### DIFF
--- a/lib/features/authentication/screens/signup/verify_email.dart
+++ b/lib/features/authentication/screens/signup/verify_email.dart
@@ -53,7 +53,24 @@ class VerifyEmailScreen extends StatelessWidget {
                 style: Theme.of(context).textTheme.labelMedium,
                 textAlign: TextAlign.center,
               ),
+              const SizedBox(height: MySizes.spaceBtwSections),
+
+              // Buttons
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () {},
+                  child: const Text(MyTexts.myContinue),
+                ),
+              ),
               const SizedBox(height: MySizes.spaceBtwItems),
+              SizedBox(
+                width: double.infinity,
+                child: TextButton(
+                  onPressed: () {},
+                  child: const Text(MyTexts.resendEmail),
+                ),
+              ),
             ],
           ),
         ),

--- a/lib/utils/constants/text_strings.dart
+++ b/lib/utils/constants/text_strings.dart
@@ -57,6 +57,7 @@ class MyTexts {
       "Your account successfully created";
   static const String yourAccountCreatedSubitle =
       "Welcome to Your Ultimate Shopping Destination: Your Account is Created, Unleash the Joy of Seamless Online Shopping";
+  static const String myContinue = 'Continue';
 
   // Home
   static const String homeAppbarTitle = '';


### PR DESCRIPTION
### Summary
Add buttons on the 'Verify Email' screen to allow users to continue or resend verification email.

### What changed?
Two buttons were added to the 'Verify Email' screen in the signup flow: one for continuing the process and another for resending the verification email. The text for the buttons is defined in the text_strings constants file.

### How to test?
1. Navigate to the 'Verify Email' screen during signup.
2. Verify that there are two new buttons: 'Continue' and 'Resend Email'.
3. Ensure that clicking these buttons does not produce any errors (although functionality is not implemented yet).

### Why make this change?
Improves user experience by providing clear actions that users can take, such as resending the verification email or continuing with the signup process.

---

![photo_4951934255785684600_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/fc6bb121-e92f-4aeb-a7bf-7f11d8a117b7.jpg)

