### PR TITLE
Forget Password Heading

### DIFF
--- a/lib/features/authentication/screens/password_configuration/forget_password.dart
+++ b/lib/features/authentication/screens/password_configuration/forget_password.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:mystore/utils/constants/sizes.dart';
+import 'package:mystore/utils/constants/text_strings.dart';
+
+class ForgetPasswordScreen extends StatelessWidget {
+  const ForgetPasswordScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: Padding(
+        padding: const EdgeInsets.all(MySizes.defaultSpace),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            /// Headings
+            Text(
+              MyTexts.forgetPasswordTitle,
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+            const SizedBox(height: MySizes.spaceBtwItems),
+            Text(
+              MyTexts.forgetPasswordSubtitle,
+              style: Theme.of(context).textTheme.labelMedium,
+            ),
+            const SizedBox(height: MySizes.spaceBtwSections * 2),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### Summary
Implemented a new screen for 'Forget Password' functionality.

### What changed?
A new file `forget_password.dart` was added in the path `lib/features/authentication/screens/password_configuration/`. This file contains the implementation for the `ForgetPasswordScreen` class, which extends `StatelessWidget` and builds a screen with appropriate headings and padding using constants from `sizes.dart` and `text_strings.dart`.

### How to test?
1. Navigate to the 'Forgot Password' section in the app.
2. Verify the presence of appropriate titles and subtitles.
3. Check that the styling and padding are applied as per the defined constants.

### Why make this change?
This change is part of the new authentication flows and facilitates users in resetting their passwords if they forget them.

---

![photo_4974644943335304494_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/ba81f30e-bc75-4009-97b3-bf9dbcac949d.jpg)

