### PR TITLE
Forget Password Email Text Field

### DIFF
--- a/lib/features/authentication/screens/password_configuration/forget_password.dart
+++ b/lib/features/authentication/screens/password_configuration/forget_password.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:iconsax/iconsax.dart';
 import 'package:mystore/utils/constants/sizes.dart';
 import 'package:mystore/utils/constants/text_strings.dart';
 
@@ -25,6 +26,14 @@ class ForgetPasswordScreen extends StatelessWidget {
               style: Theme.of(context).textTheme.labelMedium,
             ),
             const SizedBox(height: MySizes.spaceBtwSections * 2),
+
+            /// Text field
+            TextFormField(
+              decoration: const InputDecoration(
+                labelText: MyTexts.email,
+                prefixIcon: Icon(Iconsax.direct_right),
+              ),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
This pull request introduces enhancements to the ForgetPasswordScreen in the authentication module. Specifically, it adds the import for the 'iconsax' package and a TextFormField for email input featuring an 'Iconsax.direct_right' icon. Below is the detailed breakdown:

### Summary
Enhances the ForgetPasswordScreen by adding an email input field with icon support.

### What changed?
- Imported 'iconsax' package.
- Added a TextFormField to the ForgetPasswordScreen with label text and icon support.

### How to test?
1. Navigate to the ForgetPasswordScreen.
2. Verify the presence of the email input field with the 'Iconsax.direct_right' icon.

### Why make this change?
To improve user experience by providing a more interactive and visually appealing email input field.

---

![photo_4974644943335304493_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/cf7488de-528e-4e7a-8768-ac8fe4b85a64.jpg)

