### PR TITLE
Forget Password Submit Button

### DIFF
--- a/lib/features/authentication/screens/password_configuration/forget_password.dart
+++ b/lib/features/authentication/screens/password_configuration/forget_password.dart
@@ -34,6 +34,16 @@ class ForgetPasswordScreen extends StatelessWidget {
                 prefixIcon: Icon(Iconsax.direct_right),
               ),
             ),
+            const SizedBox(height: MySizes.spaceBtwSections),
+
+            /// Submit Button
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: () {},
+                child: const Text(MyTexts.submit),
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/utils/constants/text_strings.dart
+++ b/lib/utils/constants/text_strings.dart
@@ -58,6 +58,7 @@ class MyTexts {
   static const String yourAccountCreatedSubitle =
       "Welcome to Your Ultimate Shopping Destination: Your Account is Created, Unleash the Joy of Seamless Online Shopping";
   static const String myContinue = 'Continue';
+  static const String submit = 'Submit';
 
   // Home
   static const String homeAppbarTitle = '';


### PR DESCRIPTION

### Summary

Added a submit button to the Forget Password screen.

### What changed?

A submit button was added to the Forget Password screen to enhance user interaction. A new text constant `MyTexts.submit` was also introduced.

### How to test?

Navigate to the Forget Password screen and ensure the submit button is displayed and functions correctly.

### Why make this change?

To provide users with a way to submit their input on the Forget Password screen, facilitating a smoother user experience.

---

![photo_4974644943335304492_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/3b960483-d718-45b4-b673-c2d69d95b37c.jpg)

