### PR TITLE
Reset Password Title & SubTitle

### DIFF
--- a/lib/features/authentication/screens/password_configuration/reset_password.dart
+++ b/lib/features/authentication/screens/password_configuration/reset_password.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mystore/utils/constants/image_strings.dart';
 import 'package:mystore/utils/constants/sizes.dart';
+import 'package:mystore/utils/constants/text_strings.dart';
 import 'package:mystore/utils/helpers/helper_functions.dart';
 
 class ResetPasswordScreen extends StatelessWidget {
@@ -31,6 +32,20 @@ class ResetPasswordScreen extends StatelessWidget {
               Image(
                 image: const AssetImage(MyImages.deliveredEmailIllustration),
                 width: MyHelperFunctions.screenWidth(context) * 0.6,
+              ),
+              const SizedBox(height: MySizes.spaceBtwSections),
+
+              /// Title & SubTitle
+              Text(
+                MyTexts.changeYourPasswordTitle,
+                style: Theme.of(context).textTheme.headlineMedium,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: MySizes.spaceBtwItems),
+              Text(
+                MyTexts.changeYourPasswordSubtitle,
+                style: Theme.of(context).textTheme.labelMedium,
+                textAlign: TextAlign.center,
               ),
               const SizedBox(height: MySizes.spaceBtwSections),
             ],


### PR DESCRIPTION
### Summary
Added title and subtitle texts to the reset password screen.

### What changed?
Import `text_strings.dart` and add title and subtitle texts with appropriate styles to the reset password screen.

### How to test?
Run the application and navigate to the reset password screen. Ensure the title and subtitle texts appear appropriately styled.

### Why make this change?
Improves the user interface and provides clear context to the users on the reset password screen.

---

![photo_4974644943335304498_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/ff565125-7f05-45dc-b893-04896d4dd5f8.jpg)

