### PR TITLE
Reset Password Buttons

### DIFF
--- a/lib/features/authentication/screens/password_configuration/reset_password.dart
+++ b/lib/features/authentication/screens/password_configuration/reset_password.dart
@@ -48,6 +48,23 @@ class ResetPasswordScreen extends StatelessWidget {
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: MySizes.spaceBtwSections),
+
+              /// Buttons
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () {},
+                  child: const Text(MyTexts.done),
+                ),
+              ),
+              const SizedBox(height: MySizes.spaceBtwItems),
+              SizedBox(
+                width: double.infinity,
+                child: TextButton(
+                  onPressed: () {},
+                  child: const Text(MyTexts.resendEmail),
+                ),
+              ),
             ],
           ),
         ),

--- a/lib/utils/constants/text_strings.dart
+++ b/lib/utils/constants/text_strings.dart
@@ -59,6 +59,7 @@ class MyTexts {
       "Welcome to Your Ultimate Shopping Destination: Your Account is Created, Unleash the Joy of Seamless Online Shopping";
   static const String myContinue = 'Continue';
   static const String submit = 'Submit';
+  static const String done = 'Done';
 
   // Home
   static const String homeAppbarTitle = '';


### PR DESCRIPTION
### Summary
Added 'Done' and 'Resend Email' buttons to Reset Password screen.

### What changed?
- Implemented two new buttons: 'Done' and 'Resend Email' on the Reset Password screen.
- Updated `text_strings.dart` to include a new string constant `done`.

### How to test?
1. Navigate to the Reset Password screen.
2. Verify that the 'Done' and 'Resend Email' buttons are present.
3. Ensure both buttons are visible and have no functionality errors.

### Why make this change?
Enhance the user experience by providing immediate actions for resetting the password.

---

![photo_4974644943335304497_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/7ae8f15c-26e5-4c14-b7e5-cb47abb02872.jpg)

