### PR TITLE
Reset Passwod Route

### DIFF
--- a/lib/features/authentication/screens/password_configuration/forget_password.dart
+++ b/lib/features/authentication/screens/password_configuration/forget_password.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:iconsax/iconsax.dart';
 import 'package:mystore/utils/constants/sizes.dart';
 import 'package:mystore/utils/constants/text_strings.dart';
+import 'package:mystore/utils/navigation/go_routes.dart';
 
 class ForgetPasswordScreen extends StatelessWidget {
   const ForgetPasswordScreen({super.key});
@@ -40,7 +42,9 @@ class ForgetPasswordScreen extends StatelessWidget {
             SizedBox(
               width: double.infinity,
               child: ElevatedButton(
-                onPressed: () {},
+                onPressed: () {
+                  context.goNamed(MyRoutes.resetPassword.name);
+                },
                 child: const Text(MyTexts.submit),
               ),
             ),

--- a/lib/utils/navigation/go_routes.dart
+++ b/lib/utils/navigation/go_routes.dart
@@ -4,6 +4,7 @@ import 'package:mystore/common/widgets/success_screen/success_screen.dart';
 import 'package:mystore/features/authentication/screens/login/login.dart';
 import 'package:mystore/features/authentication/screens/onboarding/onboarding.dart';
 import 'package:mystore/features/authentication/screens/password_configuration/forget_password.dart';
+import 'package:mystore/features/authentication/screens/password_configuration/reset_password.dart';
 import 'package:mystore/features/authentication/screens/signup/signup.dart';
 import 'package:mystore/features/authentication/screens/signup/verify_email.dart';
 
@@ -14,6 +15,7 @@ enum MyRoutes {
   verifyEmail,
   success,
   forgetPassword,
+  resetPassword,
 }
 
 class AppRoute {
@@ -33,6 +35,7 @@ class AppRoute {
   static const String _verifyEmail = 'verify_email';
   static const String _success = 'success';
   static const String _forgetPassword = 'forget_password';
+  static const String _resetPassword = 'reset_password';
 
   static final _routes = GoRouter(
     navigatorKey: _rootNavigatorKey,
@@ -53,13 +56,11 @@ class AppRoute {
             path: _signup,
             name: MyRoutes.signup.name,
             builder: (context, state) => const SignupScreen(),
-            routes: [
-              GoRoute(
-                path: _verifyEmail,
-                name: MyRoutes.verifyEmail.name,
-                builder: (context, state) => const VerifyEmailScreen(),
-              ),
-            ],
+          ),
+          GoRoute(
+            path: _verifyEmail,
+            name: MyRoutes.verifyEmail.name,
+            builder: (context, state) => const VerifyEmailScreen(),
           ),
 
           // Forget Password
@@ -67,6 +68,11 @@ class AppRoute {
             path: _forgetPassword,
             name: MyRoutes.forgetPassword.name,
             builder: (context, state) => const ForgetPasswordScreen(),
+          ),
+          GoRoute(
+            path: _resetPassword,
+            name: MyRoutes.resetPassword.name,
+            builder: (context, state) => const ResetPasswordScreen(),
           ),
         ],
       ),


### PR DESCRIPTION
### Summary
Added navigation functionality to the forget password submit button and updated routes to include the reset password screen.

### What changed?
1. Updated `forget_password.dart` to include navigation to the reset password screen upon submit button press.
2. Added a new route for the `reset_password` screen in `go_routes.dart`.

### How to test?
1. Navigate to the forget password screen.
2. Press the submit button.
3. Verify that the app navigates to the reset password screen.

### Why make this change?
This change ensures that users can navigate to the reset password screen directly from the forget password screen, improving the user experience.

---

