### PR TITLE
Bottom Navigation Bar

### DIFF
--- a/lib/features/authentication/screens/login/widgets/login_form.dart
+++ b/lib/features/authentication/screens/login/widgets/login_form.dart
@@ -69,7 +69,9 @@ class LoginForm extends StatelessWidget {
             SizedBox(
               width: double.infinity,
               child: ElevatedButton(
-                onPressed: () {},
+                onPressed: () {
+                  context.goNamed('home');
+                },
                 child: const Text(MyTexts.signIn),
               ),
             ),

--- a/lib/navigation_menu.dart
+++ b/lib/navigation_menu.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:iconsax/iconsax.dart';
+import 'package:mystore/utils/constants/colors.dart';
+import 'package:mystore/utils/helpers/helper_functions.dart';
+
+class NavigationMenu extends StatelessWidget {
+  const NavigationMenu({super.key, required this.child});
+
+  final Widget child;
+  static final ValueNotifier<int> selectedIndexNotifier = ValueNotifier<int>(0);
+
+  static final List<String> routes = [
+    '/home',
+    '/store',
+    '/wishlist',
+    '/profile',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final darkMode = MyHelperFunctions.isDarkMode(context);
+
+    return ValueListenableBuilder(
+      valueListenable: selectedIndexNotifier,
+      builder: (context, selectedIndex, _) {
+        return Scaffold(
+          bottomNavigationBar: NavigationBar(
+            height: 80,
+            elevation: 0,
+            selectedIndex: selectedIndex,
+            onDestinationSelected: (index) {
+              selectedIndexNotifier.value = index;
+              context.go(routes[index]);
+            },
+            backgroundColor: darkMode ? MyColors.black : Colors.white,
+            indicatorColor: darkMode
+                ? MyColors.white.withOpacity(0.1)
+                : MyColors.black.withOpacity(0.1),
+            destinations: const [
+              NavigationDestination(icon: Icon(Iconsax.home), label: 'Home'),
+              NavigationDestination(icon: Icon(Iconsax.shop), label: 'Store'),
+              NavigationDestination(
+                  icon: Icon(Iconsax.heart), label: 'Wishlist'),
+              NavigationDestination(icon: Icon(Iconsax.user), label: 'Profile'),
+            ],
+          ),
+          body: child,
+        );
+      },
+    );
+  }
+}

--- a/lib/utils/navigation/go_routes.dart
+++ b/lib/utils/navigation/go_routes.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
+
 import 'package:go_router/go_router.dart';
-import 'package:mystore/common/widgets/success_screen/success_screen.dart';
+
 import 'package:mystore/features/authentication/screens/login/login.dart';
 import 'package:mystore/features/authentication/screens/onboarding/onboarding.dart';
 import 'package:mystore/features/authentication/screens/password_configuration/forget_password.dart';
 import 'package:mystore/features/authentication/screens/password_configuration/reset_password.dart';
 import 'package:mystore/features/authentication/screens/signup/signup.dart';
 import 'package:mystore/features/authentication/screens/signup/verify_email.dart';
+import 'package:mystore/navigation_menu.dart';
 
 enum MyRoutes {
   onboarding,
@@ -41,11 +43,14 @@ class AppRoute {
     navigatorKey: _rootNavigatorKey,
     initialLocation: _onboarding,
     routes: [
+      // Onboarding
       GoRoute(
         path: _onboarding,
         name: MyRoutes.onboarding.name,
         builder: (context, state) => const OnboardingScreen(),
       ),
+
+      // Login
       GoRoute(
         path: _login,
         name: MyRoutes.login.name,
@@ -73,6 +78,59 @@ class AppRoute {
             path: _resetPassword,
             name: MyRoutes.resetPassword.name,
             builder: (context, state) => const ResetPasswordScreen(),
+          ),
+        ],
+      ),
+
+      ShellRoute(
+        navigatorKey: _shellNavigatorKey,
+        builder: (context, state, child) {
+          return NavigationMenu(child: child);
+        },
+        routes: [
+          GoRoute(
+            path: '/home',
+            name: 'home',
+            pageBuilder: (BuildContext context, GoRouterState state) =>
+                NoTransitionPage<void>(
+              key: state.pageKey,
+              child: const Center(
+                child: Text('Home'),
+              ),
+            ),
+          ),
+          GoRoute(
+            path: '/store',
+            name: 'store',
+            pageBuilder: (BuildContext context, GoRouterState state) =>
+                NoTransitionPage<void>(
+              key: state.pageKey,
+              child: const Center(
+                child: Text('Store'),
+              ),
+            ),
+          ),
+          GoRoute(
+            path: '/wishlist',
+            name: 'wishlist',
+            pageBuilder: (BuildContext context, GoRouterState state) =>
+                NoTransitionPage<void>(
+              key: state.pageKey,
+              child: const Center(
+                child: Text('Wishlist'),
+              ),
+            ),
+          ),
+          GoRoute(
+            path: '/profile',
+            name: 'profile',
+            pageBuilder: (BuildContext context, GoRouterState state) =>
+                NoTransitionPage<void>(
+              key: state.pageKey,
+              child: const Center(
+                child: Text('Profile'),
+              ),
+            ),
           ),
         ],
       ),


### PR DESCRIPTION

### Summary

Added navigation menu and home route, updated login form button to navigate to home.

### What changed?

- Updated `login_form.dart` to navigate to home route upon login button press.
- Created `navigation_menu.dart` for the bottom navigation bar with routes for home, store, wishlist, and profile.
- Updated `go_routes.dart` to include shell routes for the navigation menu.

### How to test?

1. Run the application.
2. Navigate to the login screen and press the login button.
3. Verify that the app navigates to the home screen with the bottom navigation bar.
4. Use the bottom navigation bar to switch between home, store, wishlist, and profile.

### Why make this change?

To enhance the user experience with a bottom navigation menu and streamline navigation within the app.

---

![photo_4974644943335304490_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/54ea25ab-3da6-4e72-bd36-9e45ff8a5462.jpg)

![photo_4974644943335304489_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/dbd4ca6b-053e-4ee0-b3a8-2fb4d4922ef1.jpg)

