### PR TITLE
Code refactoring

### DIFF
--- a/lib/common/widgets/custom_shapes/containers/primary_header_container.dart
+++ b/lib/common/widgets/custom_shapes/containers/primary_header_container.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:mystore/common/widgets/custom_shapes/containers/circular_container.dart';
+import 'package:mystore/common/widgets/custom_shapes/curved_edges/curved_edges_widgets.dart';
+import 'package:mystore/utils/constants/colors.dart';
+
+class MyPrimaryHeaderContainer extends StatelessWidget {
+  const MyPrimaryHeaderContainer({
+    super.key,
+    required this.child,
+  });
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return MyCurvedEdgeWidget(
+      child: Container(
+        color: MyColors.primary,
+        padding: const EdgeInsets.all(0),
+        child: SizedBox(
+          height: 400,
+          child: Stack(
+            children: [
+              Positioned(
+                top: -150,
+                right: -250,
+                child: MyCircularContainer(
+                    backgroundColor: MyColors.textWhite.withOpacity(0.1)),
+              ),
+              Positioned(
+                top: 100,
+                right: -300,
+                child: MyCircularContainer(
+                    backgroundColor: MyColors.textWhite.withOpacity(0.1)),
+              ),
+              child,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/common/widgets/custom_shapes/curved_edges/curved_edges_widgets.dart
+++ b/lib/common/widgets/custom_shapes/curved_edges/curved_edges_widgets.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:mystore/common/widgets/custom_shapes/curved_edges/curved_edges.dart';
+
+class MyCurvedEdgeWidget extends StatelessWidget {
+  const MyCurvedEdgeWidget({
+    super.key,
+    this.child,
+  });
+
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipPath(
+      clipper: MyCustomCurvedEdges(),
+      child: child,
+    );
+  }
+}

--- a/lib/features/shop/screens/home/home.dart
+++ b/lib/features/shop/screens/home/home.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 
-import 'package:mystore/common/widgets/custom_shapes/containers/circular_container.dart';
-import 'package:mystore/common/widgets/custom_shapes/curved_edges/curved_edges.dart';
-import 'package:mystore/utils/constants/colors.dart';
+import 'package:mystore/common/widgets/custom_shapes/containers/primary_header_container.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -13,33 +11,8 @@ class HomeScreen extends StatelessWidget {
       body: SingleChildScrollView(
         child: Column(
           children: [
-            ClipPath(
-              clipper: MyCustomCurvedEdges(),
-              child: Container(
-                color: MyColors.primary,
-                padding: const EdgeInsets.all(0),
-                child: SizedBox(
-                  height: 400,
-                  child: Stack(
-                    children: [
-                      Positioned(
-                        top: -150,
-                        right: -250,
-                        child: MyCircularContainer(
-                            backgroundColor:
-                                MyColors.textWhite.withOpacity(0.1)),
-                      ),
-                      Positioned(
-                        top: 100,
-                        right: -300,
-                        child: MyCircularContainer(
-                            backgroundColor:
-                                MyColors.textWhite.withOpacity(0.1)),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
+            MyPrimaryHeaderContainer(
+              child: Container(),
             ),
           ],
         ),


### PR DESCRIPTION
### Summary
Refactored the header of the HomeScreen to use a new `MyPrimaryHeaderContainer` widget for improved code reuse and readability.

### What changed?
- Added `primary_header_container.dart` with a new `MyPrimaryHeaderContainer` widget.
- Created `curved_edges_widgets.dart` with a `MyCurvedEdgeWidget` widget.
- Updated `HomeScreen` to use `MyPrimaryHeaderContainer` instead of inline ClipPath and Stack code.

### How to test?
1. Navigate to the HomeScreen in the application.
2. Verify the header renders correctly with the new `MyPrimaryHeaderContainer` implementation.

### Why make this change?
This change improves code reuse and readability by encapsulating the header implementation into its own widget.

---

