### PR TITLE
Custom App Bar

### DIFF
--- a/lib/common/widgets/appbar/appbar.dart
+++ b/lib/common/widgets/appbar/appbar.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:iconsax/iconsax.dart';
+import 'package:mystore/utils/constants/sizes.dart';
+import 'package:mystore/utils/device/device_utility.dart';
+
+class MyAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const MyAppBar({
+    super.key,
+    this.title,
+    this.showBackArrow = false,
+    this.leadingIcon,
+    this.actions,
+    this.leadingOnPressed,
+  });
+
+  final Widget? title;
+  final bool showBackArrow;
+  final IconData? leadingIcon;
+  final List<Widget>? actions;
+  final VoidCallback? leadingOnPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: MySizes.md),
+      child: AppBar(
+        automaticallyImplyLeading: false,
+        leading: showBackArrow
+            ? IconButton(
+                onPressed: () {
+                  context.pop();
+                },
+                icon: const Icon(Iconsax.arrow_left),
+              )
+            : leadingIcon != null
+                ? IconButton(
+                    onPressed: leadingOnPressed,
+                    icon: Icon(leadingIcon),
+                  )
+                : null,
+        title: title,
+        actions: actions,
+      ),
+    );
+  }
+
+  @override
+  Size get preferredSize => Size.fromHeight(MyDeviceUtils.getAppBarHeight());
+}

--- a/lib/features/shop/screens/home/home.dart
+++ b/lib/features/shop/screens/home/home.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:mystore/common/widgets/appbar/appbar.dart';
 
 import 'package:mystore/common/widgets/custom_shapes/containers/primary_header_container.dart';
+import 'package:mystore/utils/constants/colors.dart';
+import 'package:mystore/utils/constants/text_strings.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -12,7 +15,31 @@ class HomeScreen extends StatelessWidget {
         child: Column(
           children: [
             MyPrimaryHeaderContainer(
-              child: Container(),
+              child: Column(
+                children: [
+                  MyAppBar(
+                    title: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          MyTexts.homeAppbarTitle,
+                          style: Theme.of(context)
+                              .textTheme
+                              .labelMedium!
+                              .apply(color: MyColors.grey),
+                        ),
+                        Text(
+                          MyTexts.homeAppbarSubTitle,
+                          style: Theme.of(context)
+                              .textTheme
+                              .headlineSmall!
+                              .apply(color: MyColors.white),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
             ),
           ],
         ),

--- a/lib/utils/constants/text_strings.dart
+++ b/lib/utils/constants/text_strings.dart
@@ -62,5 +62,6 @@ class MyTexts {
   static const String done = 'Done';
 
   // Home
-  static const String homeAppbarTitle = '';
+  static const String homeAppbarTitle = 'Good day for shopping';
+  static const String homeAppbarSubTitle = 'Imandra Cardenas';
 }


### PR DESCRIPTION

### Summary

The PR refactors the home appbar, integrating a new custom MyAppBar widget. This includes added title and subtitle properties, and customizable leading icons.

### What changed?

- Added a new MyAppBar widget to lib/common/widgets/appbar/appbar.dart
- Updated HomeScreen to use MyAppBar with added titles and dynamic leading icons
- Updated constants in lib/utils/constants/text_strings.dart for title and subtitle texts

### How to test?

1. Navigate to the home screen
2. Verify that the new title and subtitle are displayed correctly
3. Check the behavior of the back arrow and leading icons

### Why make this change?

The primary motivation is to improve code reusability and maintainability by abstracting the appbar into a custom widget, enhancing consistency across various app screens.

---

![photo_4974644943335304486_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/34be1454-9c57-4142-9ad1-c735722a0ccd.jpg)

