### PR TITLE
Cart Counter Icon

### DIFF
--- a/lib/common/widgets/product/cart/cart_menu_icon.dart
+++ b/lib/common/widgets/product/cart/cart_menu_icon.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+import 'package:iconsax/iconsax.dart';
+
+import 'package:mystore/utils/constants/colors.dart';
+
+class CartCounterIcon extends StatelessWidget {
+  const CartCounterIcon({
+    super.key,
+    required this.iconColor,
+    required this.onPressed,
+  });
+
+  final Color iconColor;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        IconButton(
+          onPressed: onPressed,
+          icon: Icon(
+            Iconsax.shopping_bag,
+            color: iconColor,
+          ),
+        ),
+        Positioned(
+          right: 0,
+          child: Container(
+            width: 18,
+            height: 18,
+            decoration: BoxDecoration(
+              color: MyColors.black,
+              borderRadius: BorderRadius.circular(100),
+            ),
+            child: Center(
+              child: Text(
+                '2',
+                style: Theme.of(context)
+                    .textTheme
+                    .labelLarge!
+                    .apply(color: MyColors.white, fontSizeFactor: 0.8),
+              ),
+            ),
+          ),
+        )
+      ],
+    );
+  }
+}


### PR DESCRIPTION
### Summary
Add a cart menu icon counter widget.

### What changed?
Created a new file `cart_menu_icon.dart` which adds a `CartCounterIcon` widget. This widget displays a shopping bag icon with a counter badge positioned at the top right, using `Iconsax` for the icon and custom colors.

### How to test?
Create a screen in the Flutter project that includes the `CartCounterIcon` widget. Ensure the counter badge appears correctly and the `onPressed` callback is functional.

### Why make this change?
This change is aimed at enhancing the user interface by providing a visual indication of the number of items in the cart, improving user experience.

---

![photo_4974644943335304486_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/cf5b06a0-b130-4e32-9572-5ea9a5e8a4ce.jpg)

