### PR TITLE
Home categories

### DIFF
--- a/.dart_tool/package_config.json
+++ b/.dart_tool/package_config.json
@@ -734,7 +734,11 @@
       "languageVersion": "3.4"
     }
   ],
+<<<<<<< HEAD
   "generated": "2024-07-18T16:42:42.141856Z",
+=======
+  "generated": "2024-07-18T16:41:21.945770Z",
+>>>>>>> a76522d (Home categories)
   "generator": "pub",
   "generatorVersion": "3.4.3",
   "flutterRoot": "file:///D:/flutter_windows_3.13.7-stable/flutter",

--- a/lib/common/widgets/image_text_widgets/vertical_image_text.dart
+++ b/lib/common/widgets/image_text_widgets/vertical_image_text.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+import 'package:mystore/utils/constants/colors.dart';
+import 'package:mystore/utils/constants/sizes.dart';
+import 'package:mystore/utils/helpers/helper_functions.dart';
+
+class MyVerticalImageText extends StatelessWidget {
+  const MyVerticalImageText({
+    super.key,
+    required this.image,
+    required this.title,
+    this.textColor = MyColors.white,
+    this.backgroundColor = MyColors.white,
+    this.onTap,
+  });
+
+  final String image, title;
+  final Color textColor;
+  final Color? backgroundColor;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = MyHelperFunctions.isDarkMode(context);
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.only(right: MySizes.spaceBtwItems),
+        child: Column(
+          children: [
+            /// Circular Icon
+            Container(
+              width: 56,
+              height: 56,
+              padding: const EdgeInsets.all(MySizes.sm),
+              decoration: BoxDecoration(
+                color:
+                    backgroundColor ?? (dark ? MyColors.dark : MyColors.white),
+                borderRadius: BorderRadius.circular(100),
+              ),
+              child: Center(
+                child: Image(
+                  image: AssetImage(image),
+                  fit: BoxFit.cover,
+                  color: dark ? MyColors.light : MyColors.dark,
+                ),
+              ),
+            ),
+            const SizedBox(height: MySizes.spaceBtwItems / 2),
+
+            /// Text
+            SizedBox(
+              width: 55,
+              child: Text(
+                title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.labelMedium!.apply(
+                      color: textColor,
+                    ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/shop/screens/home/home.dart
+++ b/lib/features/shop/screens/home/home.dart
@@ -4,6 +4,7 @@ import 'package:mystore/common/widgets/custom_shapes/containers/primary_header_c
 import 'package:mystore/common/widgets/custom_shapes/containers/search_container.dart';
 import 'package:mystore/common/widgets/texts/section_heading.dart';
 import 'package:mystore/features/shop/screens/home/widgets/home_appbar.dart';
+import 'package:mystore/features/shop/screens/home/widgets/home_categories.dart';
 import 'package:mystore/utils/constants/sizes.dart';
 
 class HomeScreen extends StatelessWidget {
@@ -36,8 +37,12 @@ class HomeScreen extends StatelessWidget {
                         MySectionHeading(
                           title: 'Popular Categories',
                           showActionButton: false,
+                          textColor: Colors.white,
                         ),
                         SizedBox(height: MySizes.spaceBtwItems),
+
+                        /// Categories
+                        HomeCategories(),
                       ],
                     ),
                   ),

--- a/lib/features/shop/screens/home/widgets/home_categories.dart
+++ b/lib/features/shop/screens/home/widgets/home_categories.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+import 'package:mystore/common/widgets/image_text_widgets/vertical_image_text.dart';
+import 'package:mystore/utils/constants/image_strings.dart';
+
+class HomeCategories extends StatelessWidget {
+  const HomeCategories({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 80,
+      child: ListView.builder(
+        shrinkWrap: true,
+        itemCount: 6,
+        scrollDirection: Axis.horizontal,
+        itemBuilder: (context, index) {
+          return MyVerticalImageText(
+            title: 'Shoes',
+            image: MyImages.shoeIcon,
+            onTap: () {},
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### Summary
Added new home categories section and vertical image text widgets.

### What changed?
- Created MyVerticalImageText widget in `lib/common/widgets/image_text_widgets/vertical_image_text.dart`
- Created HomeCategories widget and integrated it into the HomeScreen in `lib/features/shop/screens/home/home.dart`
- Updated pubspec.lock with latest dependencies

### How to test?
1. Navigate to the Home Screen in the application
2. Verify the 'Popular Categories' section is present
3. Verify the vertical image text widgets are displaying correctly
4. Tap on the categories to ensure onTap is functional

### Why make this change?
To enhance the visual elements of the Home Screen by adding a vertical layout for image text widgets and a dedicated section for popular categories.

---

![photo_4974644943335304483_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/ebbb3a85-cace-48e6-a6db-f58b6dea04b2.jpg)

