### PR TITLE
Add dependency

### DIFF
--- a/.dart_tool/package_config.json
+++ b/.dart_tool/package_config.json
@@ -98,6 +98,12 @@
       "languageVersion": "3.0"
     },
     {
+      "name": "carousel_slider",
+      "rootUri": "file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/carousel_slider-4.2.1",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
       "name": "characters",
       "rootUri": "file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/characters-1.3.0",
       "packageUri": "lib/",
@@ -734,7 +740,7 @@
       "languageVersion": "3.4"
     }
   ],
-  "generated": "2024-07-18T19:47:27.670652Z",
+  "generated": "2024-07-18T19:49:29.374312Z",
   "generator": "pub",
   "generatorVersion": "3.4.3",
   "flutterRoot": "file:///D:/flutter_windows_3.13.7-stable/flutter",

--- a/.dart_tool/package_config_subset
+++ b/.dart_tool/package_config_subset
@@ -62,6 +62,10 @@ built_value
 3.0
 file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/built_value-8.9.2/
 file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/built_value-8.9.2/lib/
+carousel_slider
+2.12
+file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/carousel_slider-4.2.1/
+file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/carousel_slider-4.2.1/lib/
 characters
 2.12
 file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/characters-1.3.0/

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -129,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.9.2"
+  carousel_slider:
+    dependency: "direct main"
+    description:
+      name: carousel_slider
+      sha256: "9c695cc963bf1d04a47bd6021f68befce8970bcd61d24938e1fb0918cf5d9c42"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.1"
   characters:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   injectable: ^2.4.2
   url_launcher: ^6.3.0
   path_provider: ^2.1.3
+  carousel_slider: ^4.2.1
   flutter_native_splash: ^2.4.1
   smooth_page_indicator: ^1.1.0
 


### PR DESCRIPTION
### Summary

Add carousel_slider package to the project dependencies.

### What changed?

Updated `pubspec.yaml` to include `carousel_slider: ^4.2.1`.
Modified `package_config.json` and `package_config_subset` to include the `carousel_slider` package with version `4.2.1` and language version `2.12`.

### How to test?

Verify that the project builds successfully and that the `carousel_slider` package functions as expected within the project.

### Why make this change?

The `carousel_slider` package is needed to implement a carousel slider feature in the application.

---

