### PR TITLE
Product Title Text

### DIFF
--- a/lib/common/widgets/texts/product_title_text.dart
+++ b/lib/common/widgets/texts/product_title_text.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class MyProductTitleText extends StatelessWidget {
+  const MyProductTitleText({
+    super.key,
+    required this.title,
+    this.smallSize = false,
+    this.maxLines = 2,
+    this.textAlign = TextAlign.left,
+  });
+
+  final String title;
+  final bool smallSize;
+  final int maxLines;
+  final TextAlign? textAlign;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      title,
+      style: smallSize
+          ? Theme.of(context).textTheme.labelLarge
+          : Theme.of(context).textTheme.titleSmall,
+      overflow: TextOverflow.ellipsis,
+      maxLines: maxLines,
+      textAlign: textAlign,
+    );
+  }
+}


### PR DESCRIPTION
### Summary
Added a new `MyProductTitleText` widget to enhance UI flexibility.

### What changed?
- Implemented `MyProductTitleText` which is a customizable text widget for product titles.
- Features include adjustable text size, alignment, and maximum lines.
- Uses themes for text styling (`labelLarge` for small size and `titleSmall` for default size).

### How to test?
- Integrate and render `MyProductTitleText` in a sample screen.
- Verify text displays correctly with different sizes, alignments, and line limits.

### Why make this change?
Enhances customization and reuse of product title text elements across the application.

---

![photo_4974644943335304480_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/85048a67-4491-4d7c-a573-2d4bca6e9eab.jpg)

