### PR TITLE
Vertical Product Card Details

### DIFF
--- a/lib/common/widgets/product/product_cards/product_card_vertical.dart
+++ b/lib/common/widgets/product/product_cards/product_card_vertical.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:iconsax/iconsax.dart';
 
 import 'package:mystore/common/styles/shadows.dart';
-import 'package:mystore/common/widgets/custom_shapes/containers/circular_container.dart';
 import 'package:mystore/common/widgets/custom_shapes/containers/rounded_container.dart';
 import 'package:mystore/common/widgets/icons/circular_icon.dart';
 import 'package:mystore/common/widgets/images/rounded_image.dart';
+import 'package:mystore/common/widgets/texts/product_title_text.dart';
 import 'package:mystore/utils/constants/colors.dart';
 import 'package:mystore/utils/constants/image_strings.dart';
 import 'package:mystore/utils/constants/sizes.dart';
@@ -18,64 +18,136 @@ class MyProductCardVertical extends StatelessWidget {
   Widget build(BuildContext context) {
     final dark = MyHelperFunctions.isDarkMode(context);
 
-    return Container(
-      width: 180,
-      padding: const EdgeInsets.all(1),
-      decoration: BoxDecoration(
-        boxShadow: [MyShadowStyle.verticalProductShadow],
-        borderRadius: BorderRadius.circular(MySizes.productImageRadius),
-        color: dark ? MyColors.darkerGrey : MyColors.white,
-      ),
-      child: Column(
-        children: [
-          /// Thumbnail, Wishlist Button, Discount Tag
-          MyRoundedContainer(
-            height: 180,
-            backgroundColor: dark ? MyColors.black : MyColors.light,
-            child: Stack(
-              children: [
-                /// Thumbnail Image
-                /// MyRoundedImage(
-                const MyRoundedImage(
-                  imageUrl: MyImages.productImage2,
-                  applyImageRadius: true,
-                ),
+    return GestureDetector(
+      onTap: () {},
+      child: Container(
+        width: 180,
+        padding: const EdgeInsets.all(1),
+        decoration: BoxDecoration(
+          boxShadow: [MyShadowStyle.verticalProductShadow],
+          borderRadius: BorderRadius.circular(MySizes.productImageRadius),
+          color: dark ? MyColors.darkerGrey : MyColors.white,
+        ),
+        child: Column(
+          children: [
+            /// Thumbnail, Wishlist Button, Discount Tag
+            MyRoundedContainer(
+              height: 180,
+              backgroundColor: dark ? MyColors.black : MyColors.light,
+              child: Stack(
+                children: [
+                  /// Thumbnail Image
+                  /// MyRoundedImage(
+                  const MyRoundedImage(
+                    imageUrl: MyImages.productImage2,
+                    applyImageRadius: true,
+                  ),
 
-                /// Sale Tag
-                Positioned(
-                  top: 16,
-                  left: 4,
-                  child: MyRoundedContainer(
-                    radius: MySizes.sm,
-                    backgroundColor: MyColors.secondary.withOpacity(0.8),
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: MySizes.sm,
-                      vertical: MySizes.xs,
-                    ),
-                    child: Text(
-                      '25%',
-                      style: Theme.of(context)
-                          .textTheme
-                          .labelLarge!
-                          .apply(color: MyColors.black),
+                  /// Sale Tag
+                  Positioned(
+                    top: 16,
+                    left: 4,
+                    child: MyRoundedContainer(
+                      radius: MySizes.sm,
+                      backgroundColor: MyColors.secondary.withOpacity(0.8),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: MySizes.sm,
+                        vertical: MySizes.xs,
+                      ),
+                      child: Text(
+                        '25%',
+                        style: Theme.of(context)
+                            .textTheme
+                            .labelLarge!
+                            .apply(color: MyColors.black),
+                      ),
                     ),
                   ),
-                ),
 
-                /// Favorite Icon Button
-                Positioned(
-                  top: 4,
-                  right: 4,
-                  child: MyCircularIcon(
-                    icon: Iconsax.heart5,
-                    color: Colors.red,
-                    onPressed: () {},
+                  /// Favorite Icon Button
+                  Positioned(
+                    top: 4,
+                    right: 4,
+                    child: MyCircularIcon(
+                      icon: Iconsax.heart5,
+                      color: Colors.red,
+                      onPressed: () {},
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
-          ),
-        ],
+            const SizedBox(
+              height: MySizes.spaceBtwItems / 2,
+            ),
+
+            /// Details
+            Padding(
+              padding: const EdgeInsets.only(left: MySizes.sm),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const MyProductTitleText(
+                    title: 'Futuristic Sneakers',
+                    smallSize: true,
+                  ),
+                  const SizedBox(
+                    height: MySizes.spaceBtwItems / 2,
+                  ),
+                  Row(
+                    children: [
+                      Text(
+                        'Close up',
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 1,
+                        style: Theme.of(context).textTheme.labelMedium,
+                      ),
+                      const SizedBox(width: MySizes.xs),
+                      const Icon(
+                        Iconsax.verify5,
+                        color: MyColors.primary,
+                        size: MySizes.iconXs,
+                      ),
+                    ],
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      /// Price
+                      Text(
+                        '\$35.5',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.headlineMedium,
+                      ),
+
+                      Container(
+                        decoration: const BoxDecoration(
+                          color: MyColors.dark,
+                          borderRadius: BorderRadius.only(
+                            topLeft: Radius.circular(MySizes.cardRadiusMd),
+                            bottomRight:
+                                Radius.circular(MySizes.productImageRadius),
+                          ),
+                        ),
+                        child: const SizedBox(
+                          width: MySizes.iconLg * 1.2,
+                          height: MySizes.iconLg * 1.2,
+                          child: Center(
+                            child: Icon(
+                              Iconsax.add,
+                              color: MyColors.white,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
This PR introduces two main changes:

1. Add a `GestureDetector` to the `MyProductCardVertical` widget to handle tap events.
2. Add a `MyProductTitleText` widget to display the product title.

### Summary

- Added `GestureDetector` to handle tap events on `MyProductCardVertical`.
- Added `MyProductTitleText` to display the product title.

### What changed?

- Wrapped the `Container` widget in `MyProductCardVertical` with a `GestureDetector` to handle taps.
- Replaced the old product title implementation with the new `MyProductTitleText` widget for a consistent design.
- Made minor adjustments to the layout and padding to accommodate the new elements.

### How to test?

1. Render the `MyProductCardVertical` widget in the app.
2. Tap on the product card and ensure the tap event is handled (e.g., print a console log).
3. Verify the product title is displayed using the new `MyProductTitleText` widget.

### Why make this change?

This change enhances the usability and design consistency of the `MyProductCardVertical` widget by adding tap interaction and using a standardized text widget for product titles.


---

![photo_4974644943335304481_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/e8724536-6ad2-476e-82c9-5fd9fb836cfb.jpg)

