### PR TITLE
Store Route

### DIFF
--- a/lib/utils/navigation/go_routes.dart
+++ b/lib/utils/navigation/go_routes.dart
@@ -9,6 +9,7 @@ import 'package:mystore/features/authentication/screens/password_configuration/r
 import 'package:mystore/features/authentication/screens/signup/signup.dart';
 import 'package:mystore/features/authentication/screens/signup/verify_email.dart';
 import 'package:mystore/features/shop/screens/home/home.dart';
+import 'package:mystore/features/shop/screens/store/store.dart';
 import 'package:mystore/navigation_menu.dart';
 
 enum MyRoutes {
@@ -20,6 +21,7 @@ enum MyRoutes {
   forgetPassword,
   resetPassword,
   home,
+  store,
 }
 
 class AppRoute {
@@ -41,6 +43,7 @@ class AppRoute {
   static const String _forgetPassword = 'forget_password';
   static const String _resetPassword = 'reset_password';
   static const String _home = '/home';
+  static const String _store = '/store';
 
   static final _routes = GoRouter(
     navigatorKey: _rootNavigatorKey,
@@ -97,15 +100,9 @@ class AppRoute {
             builder: (context, state) => const HomeScreen(),
           ),
           GoRoute(
-            path: '/store',
-            name: 'store',
-            pageBuilder: (BuildContext context, GoRouterState state) =>
-                NoTransitionPage<void>(
-              key: state.pageKey,
-              child: const Center(
-                child: Text('Store'),
-              ),
-            ),
+            path: _store,
+            name: MyRoutes.store.name,
+            builder: (context, state) => const StoreScreen(),
           ),
           GoRoute(
             path: '/wishlist',


### PR DESCRIPTION
### Summary
Add route for store screen in navigation.

### What changed?
- Added import for `store.dart` in the navigation file
- Added `store` to the `MyRoutes` enum
- Defined `_store` route constant
- Updated `_routes` to include `store` route with `StoreScreen` as the builder

### How to test?
- Navigate to `/store` in the app to verify that the store screen loads correctly.

### Why make this change?
- To include the new store screen in the app's navigation.

---

![photo_4974644943335304476_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/731f325f-19f2-46ec-a471-8c0fa3556d4b.jpg)

