### PR TITLE
Store Screen Search Bar

### DIFF
--- a/lib/common/widgets/custom_shapes/containers/search_container.dart
+++ b/lib/common/widgets/custom_shapes/containers/search_container.dart
@@ -15,12 +15,14 @@ class MySearchContainer extends StatelessWidget {
     this.showBackground = true,
     this.showBorder = true,
     this.onTap,
+    this.padding = const EdgeInsets.symmetric(horizontal: MySizes.defaultSpace),
   });
 
   final String text;
   final IconData? icon;
   final bool showBackground, showBorder;
   final VoidCallback? onTap;
+  final EdgeInsetsGeometry padding;
 
   @override
   Widget build(BuildContext context) {
@@ -29,7 +31,7 @@ class MySearchContainer extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: MySizes.defaultSpace),
+        padding: padding,
         child: Container(
           width: MyDeviceUtils.getScreenWidth(context),
           padding: const EdgeInsets.all(MySizes.md),

--- a/lib/features/shop/screens/store/store.dart
+++ b/lib/features/shop/screens/store/store.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:mystore/common/widgets/appbar/appbar.dart';
+import 'package:mystore/common/widgets/custom_shapes/containers/search_container.dart';
 import 'package:mystore/common/widgets/product/cart/cart_menu_icon.dart';
+import 'package:mystore/utils/constants/colors.dart';
+import 'package:mystore/utils/constants/sizes.dart';
+import 'package:mystore/utils/helpers/helper_functions.dart';
 
 class StoreScreen extends StatelessWidget {
   const StoreScreen({super.key});
@@ -16,6 +20,40 @@ class StoreScreen extends StatelessWidget {
         actions: [
           MyCartCounterIcon(onPressed: () {}),
         ],
+      ),
+      body: NestedScrollView(
+        headerSliverBuilder: (context, innerBoxIsScrolled) {
+          return [
+            SliverAppBar(
+              automaticallyImplyLeading: false,
+              pinned: true,
+              floating: true,
+              backgroundColor: MyHelperFunctions.isDarkMode(context)
+                  ? MyColors.black
+                  : MyColors.white,
+              expandedHeight: 440,
+              flexibleSpace: Padding(
+                padding: const EdgeInsets.all(MySizes.defaultSpace),
+                child: ListView(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  children: const [
+                    /// Search Bar
+                    SizedBox(height: MySizes.spaceBtwItems),
+                    MySearchContainer(
+                      text: 'Search in Store',
+                      showBorder: true,
+                      showBackground: false,
+                      padding: EdgeInsets.zero,
+                    ),
+                    SizedBox(height: MySizes.spaceBtwSections),
+                  ],
+                ),
+              ),
+            ),
+          ];
+        },
+        body: Container(),
       ),
     );
   }


### PR DESCRIPTION
### Summary

Add support for custom padding to `MySearchContainer` widget and integrate it into the `StoreScreen`.

### What changed?

1. **Added padding parameter to MySearchContainer:** Now `MySearchContainer` can receive custom padding via a new `padding` parameter. 
2. **Updated Search Container in Store Screen:** Integrated `MySearchContainer` into `StoreScreen`, allowing it to utilize the new padding feature.

### How to test?

- Verify that the `MySearchContainer` displays correctly with custom padding.
- Test `StoreScreen` to ensure that `MySearchContainer` is used as expected.

### Why make this change?

This change provides more flexibility in the customization of `MySearchContainer`, allowing it to fit better in different screen layouts.

---

![photo_4974644943335304475_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/9edbf6ba-c1b0-4508-a84b-ffb3192b81fc.jpg)

