### PR TITLE
Store Featured Brands Heading

### DIFF
--- a/lib/features/shop/screens/store/store.dart
+++ b/lib/features/shop/screens/store/store.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:mystore/common/widgets/appbar/appbar.dart';
 import 'package:mystore/common/widgets/custom_shapes/containers/search_container.dart';
 import 'package:mystore/common/widgets/product/cart/cart_menu_icon.dart';
+import 'package:mystore/common/widgets/texts/section_heading.dart';
 import 'package:mystore/utils/constants/colors.dart';
 import 'package:mystore/utils/constants/sizes.dart';
 import 'package:mystore/utils/helpers/helper_functions.dart';
@@ -37,16 +38,25 @@ class StoreScreen extends StatelessWidget {
                 child: ListView(
                   shrinkWrap: true,
                   physics: const NeverScrollableScrollPhysics(),
-                  children: const [
+                  children: [
                     /// Search Bar
-                    SizedBox(height: MySizes.spaceBtwItems),
-                    MySearchContainer(
+                    const SizedBox(height: MySizes.spaceBtwItems),
+                    const MySearchContainer(
                       text: 'Search in Store',
                       showBorder: true,
                       showBackground: false,
                       padding: EdgeInsets.zero,
                     ),
-                    SizedBox(height: MySizes.spaceBtwSections),
+                    const SizedBox(height: MySizes.spaceBtwSections),
+
+                    /// Featured Brands
+                    MySectionHeading(
+                      title: 'Featured Brand',
+                      showActionButton: true,
+                      onPressed: () {},
+                    ),
+                    const SizedBox(height: MySizes.spaceBtwItems / 1.5),
+                    
                   ],
                 ),
               ),


### PR DESCRIPTION
### Summary
Updated the store screen UI to include a section heading for the featured brand.

### What changed?
- Added a new import for `section_heading.dart`.
- Added `MySectionHeading` widget in the store screen.

### How to test?
1. Run the app and navigate to the store screen.
2. Verify that the new section heading 'Featured Brand' is displayed correctly under the search bar.
3. Check that the action button in the section heading works as expected.

### Why make this change?
To enhance the UI of the store screen by clearly demarcating the section for featured brands.

---

![photo_4974644943335304474_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/490fb8a9-d6d6-433e-af45-309345002a81.jpg)

