### PR TITLE
Custom Brand Show Case Widget

### DIFF
--- a/lib/common/widgets/brands/brand_show_case.dart
+++ b/lib/common/widgets/brands/brand_show_case.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+import 'package:mystore/common/widgets/brands/brand_card.dart';
+import 'package:mystore/common/widgets/custom_shapes/containers/rounded_container.dart';
+import 'package:mystore/utils/constants/colors.dart';
+import 'package:mystore/utils/constants/sizes.dart';
+import 'package:mystore/utils/helpers/helper_functions.dart';
+
+class MyBrandShowCase extends StatelessWidget {
+  const MyBrandShowCase({
+    super.key,
+    required this.images,
+  });
+
+  final List<String> images;
+
+  Widget brandProductImageWidget(String image, context) {
+    return Expanded(
+      child: MyRoundedContainer(
+        height: 100,
+        backgroundColor: MyHelperFunctions.isDarkMode(context)
+            ? MyColors.darkerGrey
+            : MyColors.light,
+        margin: const EdgeInsets.only(right: MySizes.sm),
+        child: Image(
+          fit: BoxFit.cover,
+          image: AssetImage(image),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MyRoundedContainer(
+      showBorder: true,
+      borderColor: MyColors.darkGrey,
+      backgroundColor: Colors.transparent,
+      padding: const EdgeInsets.all(MySizes.md),
+      margin: const EdgeInsets.only(bottom: MySizes.spaceBtwItems),
+      child: Column(
+        children: [
+          /// Brand with Product Count
+          const MyBrandCard(showBorder: false),
+
+          /// Brand Top 3 Product Images
+          Row(
+            children:
+                images.map((e) => brandProductImageWidget(e, context)).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/common/widgets/custom_shapes/containers/rounded_container.dart
+++ b/lib/common/widgets/custom_shapes/containers/rounded_container.dart
@@ -38,7 +38,10 @@ class MyRoundedContainer extends StatelessWidget {
         borderRadius: BorderRadius.circular(radius),
         border: showBorder ? Border.all(color: borderColor) : null,
       ),
-      child: child,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(radius),
+        child: child,
+      ),
     );
   }
 }

--- a/lib/features/shop/screens/store/store.dart
+++ b/lib/features/shop/screens/store/store.dart
@@ -3,12 +3,13 @@ import 'package:flutter/material.dart';
 import 'package:mystore/common/widgets/appbar/appbar.dart';
 import 'package:mystore/common/widgets/appbar/tabbar.dart';
 import 'package:mystore/common/widgets/brands/brand_card.dart';
-import 'package:mystore/common/widgets/custom_shapes/containers/rounded_container.dart';
+import 'package:mystore/common/widgets/brands/brand_show_case.dart';
 import 'package:mystore/common/widgets/custom_shapes/containers/search_container.dart';
 import 'package:mystore/common/widgets/layouts/grid_layout.dart';
 import 'package:mystore/common/widgets/product/cart/cart_menu_icon.dart';
 import 'package:mystore/common/widgets/texts/section_heading.dart';
 import 'package:mystore/utils/constants/colors.dart';
+import 'package:mystore/utils/constants/image_strings.dart';
 import 'package:mystore/utils/constants/sizes.dart';
 import 'package:mystore/utils/helpers/helper_functions.dart';
 
@@ -18,7 +19,7 @@ class StoreScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      length: 5,
+      length: 1,
       child: Scaffold(
         appBar: MyAppBar(
           title: Text(
@@ -80,10 +81,10 @@ class StoreScreen extends StatelessWidget {
                 bottom: const MyTabBar(
                   tabs: [
                     Tab(child: Text('Sports')),
-                    Tab(child: Text('Furnitures')),
-                    Tab(child: Text('Electronics')),
-                    Tab(child: Text('Clothes')),
-                    Tab(child: Text('Cosmetics')),
+                    // Tab(child: Text('Furnitures')),
+                    // Tab(child: Text('Electronics')),
+                    // Tab(child: Text('Clothes')),
+                    // Tab(child: Text('Cosmetics')),
                   ],
                 ),
               ),
@@ -91,26 +92,11 @@ class StoreScreen extends StatelessWidget {
           },
 
           /// Body
-          body: TabBarView(
-            children: [
-              Padding(
-                padding: const EdgeInsets.all(MySizes.defaultSpace),
-                child: Column(
-                  children: [
-                    /// Brands
-                    MyRoundedContainer(
-                      showBorder: true,
-                      borderColor: MyColors.darkGrey,
-                      backgroundColor: Colors.transparent,
-                      margin:
-                          const EdgeInsets.only(bottom: MySizes.spaceBtwItems),
-                      child: Column(
-                        children: [MyBrandCard(showBorder: false)],
-                      ),
-                    ),
-                  ],
-                ),
-              ),
+          body: MyBrandShowCase(
+            images: [
+              MyImages.productImage1,
+              MyImages.productImage5,
+              MyImages.productImage10,
             ],
           ),
         ),


### PR DESCRIPTION
### Summary

- Added `MyBrandShowCase` widget to `StoreScreen`.
- Updated `MyRoundedContainer` to use `ClipRRect` for clipping.
- Refactored `StoreScreen` to use new `MyBrandShowCase` widget.

### What changed?

- Created a new widget named `MyBrandShowCase` in `brand_show_case.dart`.
- Updated `MyRoundedContainer` to include a `ClipRRect` for better clipping of child widgets.
- Refactored `StoreScreen` to utilize the new `MyBrandShowCase` widget and removed old unused tabs.
- Tab count in `StoreScreen` is reduced from 5 to 1.

### How to test?

- Run the application and navigate to the `StoreScreen`.
- Verify that the `BrandShowCase` widget is displayed with images.
- Check the clipping functionality of `MyRoundedContainer`.

### Why make this change?

This change aims to improve the brand showcase presentation on the `StoreScreen` by introducing a dedicated widget and better clipping capabilities.

---

![photo_4974644943335304471_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/4551a8f4-e0e7-49c9-b1ed-6d1464511a45.jpg)

