### PR TITLE
Category Tabs Products Grid

### DIFF
--- a/lib/common/widgets/brands/brand_show_case.dart
+++ b/lib/common/widgets/brands/brand_show_case.dart
@@ -42,6 +42,7 @@ class MyBrandShowCase extends StatelessWidget {
         children: [
           /// Brand with Product Count
           const MyBrandCard(showBorder: false),
+          const SizedBox(height: MySizes.spaceBtwItems),
 
           /// Brand Top 3 Product Images
           Row(

--- a/lib/features/shop/screens/store/store.dart
+++ b/lib/features/shop/screens/store/store.dart
@@ -3,13 +3,12 @@ import 'package:flutter/material.dart';
 import 'package:mystore/common/widgets/appbar/appbar.dart';
 import 'package:mystore/common/widgets/appbar/tabbar.dart';
 import 'package:mystore/common/widgets/brands/brand_card.dart';
-import 'package:mystore/common/widgets/brands/brand_show_case.dart';
 import 'package:mystore/common/widgets/custom_shapes/containers/search_container.dart';
 import 'package:mystore/common/widgets/layouts/grid_layout.dart';
 import 'package:mystore/common/widgets/product/cart/cart_menu_icon.dart';
 import 'package:mystore/common/widgets/texts/section_heading.dart';
+import 'package:mystore/features/shop/screens/store/widgets/category_tabs.dart';
 import 'package:mystore/utils/constants/colors.dart';
-import 'package:mystore/utils/constants/image_strings.dart';
 import 'package:mystore/utils/constants/sizes.dart';
 import 'package:mystore/utils/helpers/helper_functions.dart';
 
@@ -19,7 +18,7 @@ class StoreScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      length: 1,
+      length: 5,
       child: Scaffold(
         appBar: MyAppBar(
           title: Text(
@@ -81,10 +80,10 @@ class StoreScreen extends StatelessWidget {
                 bottom: const MyTabBar(
                   tabs: [
                     Tab(child: Text('Sports')),
-                    // Tab(child: Text('Furnitures')),
-                    // Tab(child: Text('Electronics')),
-                    // Tab(child: Text('Clothes')),
-                    // Tab(child: Text('Cosmetics')),
+                    Tab(child: Text('Furnitures')),
+                    Tab(child: Text('Electronics')),
+                    Tab(child: Text('Clothes')),
+                    Tab(child: Text('Cosmetics')),
                   ],
                 ),
               ),
@@ -92,11 +91,13 @@ class StoreScreen extends StatelessWidget {
           },
 
           /// Body
-          body: MyBrandShowCase(
-            images: [
-              MyImages.productImage1,
-              MyImages.productImage5,
-              MyImages.productImage10,
+          body: TabBarView(
+            children: [
+              CategoryTabs(),
+              CategoryTabs(),
+              CategoryTabs(),
+              CategoryTabs(),
+              CategoryTabs(),
             ],
           ),
         ),

--- a/lib/features/shop/screens/store/widgets/category_tabs.dart
+++ b/lib/features/shop/screens/store/widgets/category_tabs.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:mystore/common/widgets/brands/brand_show_case.dart';
+import 'package:mystore/common/widgets/layouts/grid_layout.dart';
+import 'package:mystore/common/widgets/product/product_cards/product_card_vertical.dart';
+import 'package:mystore/common/widgets/texts/section_heading.dart';
 import 'package:mystore/utils/constants/image_strings.dart';
 import 'package:mystore/utils/constants/sizes.dart';
 
@@ -8,22 +11,38 @@ class CategoryTabs extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(MySizes.defaultSpace),
-      child: Column(
-        children: [
-          /// Brands
-          MyBrandShowCase(
-            images: [
-              MyImages.productImage1,
-              MyImages.productImage5,
-              MyImages.productImage10,
+    return ListView(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(MySizes.defaultSpace),
+          child: Column(
+            children: [
+              /// Brands
+              const MyBrandShowCase(
+                images: [
+                  MyImages.productImage1,
+                  MyImages.productImage5,
+                  MyImages.productImage10,
+                ],
+              ),
+
+              /// Products
+              MySectionHeading(title: 'You might like', onPressed: () {}),
+              const SizedBox(height: MySizes.spaceBtwItems),
+
+              MyGridLayout(
+                itemCount: 4,
+                itemBuilder: (_, index) {
+                  return const MyProductCardVertical();
+                },
+              ),
+              const SizedBox(height: MySizes.spaceBtwSections),
             ],
           ),
-
-          /// Products
-        ],
-      ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
### Summary

This PR introduces category tabs to the Store Screen and integrates product cards and section headings for better organization.

### What changed?

- Enhanced `StoreScreen` to include five category tabs: Sports, Furnitures, Electronics, Clothes, and Cosmetics.
- Refactored `StoreScreen` to utilize `CategoryTabs` widget for displaying brand showcases and product grids.
- Modified `CategoryTabs` to incorporate `MyGridLayout` for displaying product cards.
- Updated tab length in `StoreScreen` from 1 to 5.

### How to test?

1. Navigate to the Store Screen in the application.
2. Verify the presence of category tabs: Sports, Furnitures, Electronics, Clothes, and Cosmetics.
3. Ensure that each tab contains a brand showcase followed by a product grid.

### Why make this change?

This update is aimed at improving the organization and user experience of the Store Screen, making it easier to navigate between different product categories.

---


![photo_4974644943335304469_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/347152ca-018f-4866-b8ec-b2afc5a9ee81.jpg)

