### PR TITLE
Fixing backgroundColor on MyVerticalImageText

### DIFF
--- a/lib/common/widgets/image_text_widgets/vertical_image_text.dart
+++ b/lib/common/widgets/image_text_widgets/vertical_image_text.dart
@@ -10,7 +10,7 @@ class MyVerticalImageText extends StatelessWidget {
     required this.image,
     required this.title,
     this.textColor = MyColors.white,
-    this.backgroundColor = MyColors.white,
+    this.backgroundColor,
     this.onTap,
   });
 


### PR DESCRIPTION
### Summary
Made `backgroundColor` an optional parameter in `MyVerticalImageText` widget, removing its default value of `MyColors.white`.

### What changed?
In `MyVerticalImageText` widget, the `backgroundColor` parameter no longer has a default value of `MyColors.white`. Instead, it is optional. If no value is provided, it will be null.

### How to test?
1. Instantiate `MyVerticalImageText` with and without the `backgroundColor` parameter.
2. Verify that the widget does not break or show any unexpected behavior.

### Why make this change?
This change allows greater flexibility for the `MyVerticalImageText` widget, enabling the user to choose whether or not to set a background color.

---

- Before
![photo_4974644943335304466_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/f2796f14-c530-4496-bd09-b8c60ca7f72d.jpg)

- After
![photo_4974644943335304467_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/ec331c75-e4f7-42fa-9785-693b1e70a306.jpg)

