### PR TITLE
Wishlist Screen

### DIFF
--- a/lib/features/shop/screens/wishlist/wishlist.dart
+++ b/lib/features/shop/screens/wishlist/wishlist.dart
@@ -5,6 +5,9 @@ import 'package:iconsax/iconsax.dart';
 
 import 'package:mystore/common/widgets/appbar/appbar.dart';
 import 'package:mystore/common/widgets/icons/circular_icon.dart';
+import 'package:mystore/common/widgets/layouts/grid_layout.dart';
+import 'package:mystore/common/widgets/product/product_cards/product_card_vertical.dart';
+import 'package:mystore/utils/constants/sizes.dart';
 import 'package:mystore/utils/navigation/go_routes.dart';
 
 class WishlistScreen extends StatelessWidget {
@@ -24,6 +27,21 @@ class WishlistScreen extends StatelessWidget {
             },
           )
         ],
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(MySizes.defaultSpace),
+          child: Column(
+            children: [
+              MyGridLayout(
+                itemCount: 8,
+                itemBuilder: (_, index) {
+                  return const MyProductCardVertical();
+                },
+              )
+            ],
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
### Summary

Add vertical product card layout and grid layout to wishlist screen.

### What changed?

- Imported `MyGridLayout` and `MyProductCardVertical` widgets
- Added a grid layout with product cards to the wishlist screen
- Added padding around the grid layout

### How to test?

- Navigate to the wishlist screen
- Verify a grid layout with vertical product cards is rendered

### Why make this change?

This change enhances the wishlist screen by displaying products in a grid layout, improving the user experience.

---

![photo_4974644943335304465_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/bd5a519d-7b17-4024-b781-68e914149fda.jpg)

