### PR TITLE
Remove height from Primary Header Container

### DIFF
--- a/lib/common/widgets/custom_shapes/containers/primary_header_container.dart
+++ b/lib/common/widgets/custom_shapes/containers/primary_header_container.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:mystore/common/widgets/custom_shapes/containers/circular_container.dart';
 import 'package:mystore/common/widgets/custom_shapes/curved_edges/curved_edges_widgets.dart';
 import 'package:mystore/utils/constants/colors.dart';
+import 'package:mystore/utils/constants/sizes.dart';
 
 class MyPrimaryHeaderContainer extends StatelessWidget {
   const MyPrimaryHeaderContainer({
@@ -16,26 +17,24 @@ class MyPrimaryHeaderContainer extends StatelessWidget {
     return MyCurvedEdgeWidget(
       child: Container(
         color: MyColors.primary,
-        padding: const EdgeInsets.all(0),
-        child: SizedBox(
-          height: 400,
-          child: Stack(
-            children: [
-              Positioned(
-                top: -150,
-                right: -250,
-                child: MyCircularContainer(
-                    backgroundColor: MyColors.textWhite.withOpacity(0.1)),
-              ),
-              Positioned(
-                top: 100,
-                right: -300,
-                child: MyCircularContainer(
-                    backgroundColor: MyColors.textWhite.withOpacity(0.1)),
-              ),
-              child,
-            ],
-          ),
+        padding: const EdgeInsets.only(
+            bottom: MySizes.spaceBtwSections, left: 0, right: 0, top: 0),
+        child: Stack(
+          children: [
+            Positioned(
+              top: -150,
+              right: -250,
+              child: MyCircularContainer(
+                  backgroundColor: MyColors.textWhite.withOpacity(0.1)),
+            ),
+            Positioned(
+              top: 100,
+              right: -300,
+              child: MyCircularContainer(
+                  backgroundColor: MyColors.textWhite.withOpacity(0.1)),
+            ),
+            child,
+          ],
         ),
       ),
     );

--- a/lib/features/shop/screens/home/home.dart
+++ b/lib/features/shop/screens/home/home.dart
@@ -50,7 +50,6 @@ class HomeScreen extends StatelessWidget {
                       ],
                     ),
                   ),
-                  SizedBox(height: MySizes.spaceBtwSections),
                 ],
               ),
             ),


### PR DESCRIPTION
### Summary
Updated the padding in `MyPrimaryHeaderContainer` and removed redundant `SizedBox` widget from `HomeScreen` for UI cleanup.

### What changed?
- In `primary_header_container.dart`, added a bottom padding using `MySizes.spaceBtwSections` to `MyPrimaryHeaderContainer`.
- Removed the `SizedBox` widget used for spacing in the `HomeScreen` class inside `home.dart`.

### How to test?
- Verify that the padding changes in `MyPrimaryHeaderContainer` are being applied as expected.
- Ensure that the removal of the `SizedBox` widget doesn't affect the spacing in the `HomeScreen`.

### Why make this change?
These changes enhance the UI by refining the padding and removing redundant widgets, leading to cleaner and more maintainable code.

---

