### PR TITLE
User Profile Card

### DIFF
--- a/lib/common/widgets/list_tiles/user_profile_tile.dart
+++ b/lib/common/widgets/list_tiles/user_profile_tile.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:iconsax/iconsax.dart';
+import 'package:mystore/common/widgets/images/circular_image.dart';
+import 'package:mystore/utils/constants/colors.dart';
+import 'package:mystore/utils/constants/image_strings.dart';
+
+class MyUserProfileTile extends StatelessWidget {
+  const MyUserProfileTile({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: const MyCircularImage(
+        image: MyImages.user,
+        width: 50,
+        height: 50,
+        padding: 0,
+      ),
+      trailing: IconButton(
+        onPressed: () {},
+        icon: const Icon(Iconsax.edit, color: MyColors.white),
+      ),
+      title: Text(
+        'Imandra Cardenas',
+        style: Theme.of(context)
+            .textTheme
+            .headlineSmall!
+            .apply(color: MyColors.white),
+      ),
+      subtitle: Text(
+        'imandracardenas0@gmail.com',
+        style: Theme.of(context)
+            .textTheme
+            .bodyMedium!
+            .apply(color: MyColors.white),
+      ),
+    );
+  }
+}

--- a/lib/features/personalization/screens/settings/settings.dart
+++ b/lib/features/personalization/screens/settings/settings.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:iconsax/iconsax.dart';
 import 'package:mystore/common/widgets/appbar/appbar.dart';
 import 'package:mystore/common/widgets/custom_shapes/containers/primary_header_container.dart';
+import 'package:mystore/common/widgets/images/circular_image.dart';
+import 'package:mystore/common/widgets/list_tiles/user_profile_tile.dart';
 import 'package:mystore/utils/constants/colors.dart';
+import 'package:mystore/utils/constants/image_strings.dart';
 import 'package:mystore/utils/constants/sizes.dart';
 
 class SettingsScreen extends StatelessWidget {
@@ -26,7 +30,9 @@ class SettingsScreen extends StatelessWidget {
                           .apply(color: MyColors.white),
                     ),
                   ),
-                  const SizedBox(height: MySizes.spaceBtwSections),
+
+                  /// User Profile Card
+                  const MyUserProfileTile(),
                 ],
               ),
             ),


### PR DESCRIPTION
### Summary

This PR adds a user profile tile component to the settings screen.

### What changed?

- Created a new `MyUserProfileTile` widget for displaying user profile information.
- Imported and utilized the `MyUserProfileTile` in the `SettingsScreen`.

### How to test?

1. Navigate to the settings screen in the app.
2. Verify that the user profile tile is displayed correctly with the user’s image, name, and email.
3. Ensure the edit button is present but non-functional for now.

### Why make this change?

This change introduces a reusable user profile component that can be utilized across different screens where user information needs to be displayed.

---

![photo_4974644943335304462_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/9a4b846a-0154-4e22-8680-92b47703813b.jpg)

