### PR TITLE
Custom Setting Menu Tile

### DIFF
--- a/lib/common/widgets/list_tiles/settings_menu_tile.dart
+++ b/lib/common/widgets/list_tiles/settings_menu_tile.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:mystore/utils/constants/colors.dart';
+
+class MySettingMenuTile extends StatelessWidget {
+  const MySettingMenuTile(
+      {super.key,
+      required this.icon,
+      required this.title,
+      required this.subtitle,
+      this.trailing,
+      this.onTap});
+
+  final IconData icon;
+  final String title, subtitle;
+  final Widget? trailing;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(
+        icon,
+        size: 28,
+        color: MyColors.primary,
+      ),
+      title: Text(title, style: Theme.of(context).textTheme.titleMedium),
+      subtitle: Text(subtitle, style: Theme.of(context).textTheme.labelMedium),
+      trailing: trailing,
+      onTap: onTap,
+    );
+  }
+}


### PR DESCRIPTION
### Summary

Added a new reusable `MySettingMenuTile` widget to represent a settings menu item.

### What changed?

Created a new file at `lib/common/widgets/list_tiles/settings_menu_tile.dart` that defines the `MySettingMenuTile` widget. This widget includes an icon, title, subtitle, optional trailing widget, and optional onTap callback to handle user interaction.

### How to test?

1. Integrate the `MySettingMenuTile` widget in a settings screen.
2. Pass the required parameters like `icon`, `title`, and `subtitle`.
3. Optionally, add a `trailing` widget and `onTap` callback.
4. Verify that the widget is displayed correctly and interacts as expected when tapped.

### Why make this change?

To create a consistent and reusable widget for settings menu items, promoting code reuse and a consistent look-and-feel across the application.

---

