### PR TITLE
Account Settings

### DIFF
--- a/lib/features/personalization/screens/settings/settings.dart
+++ b/lib/features/personalization/screens/settings/settings.dart
@@ -3,7 +3,9 @@ import 'package:iconsax/iconsax.dart';
 import 'package:mystore/common/widgets/appbar/appbar.dart';
 import 'package:mystore/common/widgets/custom_shapes/containers/primary_header_container.dart';
 import 'package:mystore/common/widgets/images/circular_image.dart';
+import 'package:mystore/common/widgets/list_tiles/settings_menu_tile.dart';
 import 'package:mystore/common/widgets/list_tiles/user_profile_tile.dart';
+import 'package:mystore/common/widgets/texts/section_heading.dart';
 import 'package:mystore/utils/constants/colors.dart';
 import 'package:mystore/utils/constants/image_strings.dart';
 import 'package:mystore/utils/constants/sizes.dart';
@@ -33,6 +35,64 @@ class SettingsScreen extends StatelessWidget {
 
                   /// User Profile Card
                   const MyUserProfileTile(),
+                ],
+              ),
+            ),
+
+            /// Body
+            Padding(
+              padding: const EdgeInsets.all(MySizes.defaultSpace),
+              child: Column(
+                children: [
+                  /// Account Settings
+                  const MySectionHeading(
+                    title: 'Account Settings',
+                    showActionButton: false,
+                  ),
+                  const SizedBox(height: MySizes.spaceBtwItems),
+
+                  MySettingMenuTile(
+                    icon: Iconsax.safe_home,
+                    title: 'My Addresses',
+                    subtitle: 'Set shopping delivery address',
+                    onTap: () {},
+                  ),
+                  MySettingMenuTile(
+                    icon: Iconsax.shopping_cart,
+                    title: 'My Cart',
+                    subtitle: 'Add, remove products and move to checkout',
+                    onTap: () {},
+                  ),
+                  MySettingMenuTile(
+                    icon: Iconsax.bag_tick,
+                    title: 'My Orders',
+                    subtitle: 'In-progress and Completed Orders',
+                    onTap: () {},
+                  ),
+                  MySettingMenuTile(
+                    icon: Iconsax.bank,
+                    title: 'Bank Account',
+                    subtitle: 'Withdraw balance to registered bank account',
+                    onTap: () {},
+                  ),
+                  MySettingMenuTile(
+                    icon: Iconsax.discount_shape,
+                    title: 'My Coupons',
+                    subtitle: 'List of all the discounted coupons',
+                    onTap: () {},
+                  ),
+                  MySettingMenuTile(
+                    icon: Iconsax.notification,
+                    title: 'Notifications',
+                    subtitle: 'Set any kind of notification message',
+                    onTap: () {},
+                  ),
+                  MySettingMenuTile(
+                    icon: Iconsax.security_card,
+                    title: 'Account Privacy',
+                    subtitle: 'Manage data usage and connected accounts',
+                    onTap: () {},
+                  ),
                 ],
               ),
             ),


### PR DESCRIPTION
### Summary

Implemented various account settings menu tiles in the Settings screen.

### What changed?

- Added the 'Account Settings' section in the settings screen.
- Implemented multiple setting menu tiles including: My Addresses, My Cart, My Orders, Bank Account, My Coupons, Notifications, and Account Privacy.

### How to test?

1. Navigate to the settings screen.
2. Verify that the 'Account Settings' section is displayed correctly.
3. Check that each of the new setting menu tiles is present and functional with the correct icon, title, and subtitle.
4. Ensure that the 'Account Settings' title is properly styled and displayed.

### Why make this change?

This change aims to enhance user experience by consolidating various account-related settings into a single 'Account Settings' section, making it easier for users to manage their account preferences from one place.

---

![photo_4974644943335304464_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/421e2300-c308-47b3-a7c0-f776ec994b91.jpg)

