### PR TITLE
Profile Sreen Route

### DIFF
--- a/lib/common/widgets/list_tiles/user_profile_tile.dart
+++ b/lib/common/widgets/list_tiles/user_profile_tile.dart
@@ -7,7 +7,10 @@ import 'package:mystore/utils/constants/image_strings.dart';
 class MyUserProfileTile extends StatelessWidget {
   const MyUserProfileTile({
     super.key,
+    this.onPressed,
   });
+
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -19,7 +22,7 @@ class MyUserProfileTile extends StatelessWidget {
         padding: 0,
       ),
       trailing: IconButton(
-        onPressed: () {},
+        onPressed: onPressed,
         icon: const Icon(Iconsax.edit, color: MyColors.white),
       ),
       title: Text(

--- a/lib/features/personalization/screens/profile/profile.dart
+++ b/lib/features/personalization/screens/profile/profile.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:mystore/common/widgets/appbar/appbar.dart';
+
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: MyAppBar(
+        showBackArrow: true,
+        title: Text('Profile'),
+      ),
+      body: SingleChildScrollView(),
+    );
+  }
+}

--- a/lib/features/personalization/screens/settings/settings.dart
+++ b/lib/features/personalization/screens/settings/settings.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:iconsax/iconsax.dart';
 import 'package:mystore/common/widgets/appbar/appbar.dart';
 import 'package:mystore/common/widgets/custom_shapes/containers/primary_header_container.dart';
@@ -7,6 +8,7 @@ import 'package:mystore/common/widgets/list_tiles/user_profile_tile.dart';
 import 'package:mystore/common/widgets/texts/section_heading.dart';
 import 'package:mystore/utils/constants/colors.dart';
 import 'package:mystore/utils/constants/sizes.dart';
+import 'package:mystore/utils/navigation/go_routes.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
@@ -32,7 +34,11 @@ class SettingsScreen extends StatelessWidget {
                   ),
 
                   /// User Profile Card
-                  const MyUserProfileTile(),
+                  MyUserProfileTile(
+                    onPressed: () {
+                      context.goNamed(MyRoutes.profile.name);
+                    },
+                  ),
                 ],
               ),
             ),

--- a/lib/utils/navigation/go_routes.dart
+++ b/lib/utils/navigation/go_routes.dart
@@ -8,6 +8,7 @@ import 'package:mystore/features/authentication/screens/password_configuration/f
 import 'package:mystore/features/authentication/screens/password_configuration/reset_password.dart';
 import 'package:mystore/features/authentication/screens/signup/signup.dart';
 import 'package:mystore/features/authentication/screens/signup/verify_email.dart';
+import 'package:mystore/features/personalization/screens/profile/profile.dart';
 import 'package:mystore/features/personalization/screens/settings/settings.dart';
 import 'package:mystore/features/shop/screens/home/home.dart';
 import 'package:mystore/features/shop/screens/store/store.dart';
@@ -26,6 +27,7 @@ enum MyRoutes {
   store,
   wishlist,
   settings,
+  profile,
 }
 
 class AppRoute {
@@ -50,6 +52,7 @@ class AppRoute {
   static const String _store = '/store';
   static const String _wishlist = '/wishlist';
   static const String _settings = '/settings';
+  static const String _profile = 'profile';
 
   static final _routes = GoRouter(
     navigatorKey: _rootNavigatorKey,
@@ -119,6 +122,13 @@ class AppRoute {
             path: _settings,
             name: MyRoutes.settings.name,
             builder: (context, state) => const SettingsScreen(),
+            routes: [
+              GoRoute(
+                path: _profile,
+                name: MyRoutes.profile.name,
+                builder: (context, state) => const ProfileScreen(),
+              ),
+            ],
           ),
         ],
       ),


### PR DESCRIPTION
### Summary

Added navigation to the Profile screen from the Settings screen. User can now tap the edit button on the MyUserProfileTile to navigate to their Profile page.

### What changed?

1. Added an `onPressed` callback to the `MyUserProfileTile` widget to handle user interactions.
2. Created a `ProfileScreen` page in the `personalization/screens/profile/` directory.
3. Updated `SettingsScreen` to include the `ProfileScreen` navigation.
4. Modified `go_routes.dart` to add a new route for `ProfileScreen`.

### How to test?

1. Go to the Settings screen.
2. Tap the edit button on the MyUserProfileTile.
3. Verify that it navigates to the Profile screen.

### Why make this change?

To enhance the user experience by providing easy navigation to the Profile screen from the Settings screen.

---

![photo_4974644943335304459_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/41eb6bf9-24c1-44c1-abef-d1243b65bbf1.jpg)

