### PR TITLE
Proile Picture

### DIFF
--- a/lib/features/personalization/screens/profile/profile.dart
+++ b/lib/features/personalization/screens/profile/profile.dart
@@ -1,17 +1,42 @@
 import 'package:flutter/material.dart';
 import 'package:mystore/common/widgets/appbar/appbar.dart';
+import 'package:mystore/common/widgets/images/circular_image.dart';
+import 'package:mystore/utils/constants/image_strings.dart';
+import 'package:mystore/utils/constants/sizes.dart';
 
 class ProfileScreen extends StatelessWidget {
   const ProfileScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
       appBar: MyAppBar(
         showBackArrow: true,
         title: Text('Profile'),
       ),
-      body: SingleChildScrollView(),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(MySizes.defaultSpace),
+          child: Column(
+            children: [
+              /// Profile Picture
+              SizedBox(
+                width: double.infinity,
+                child: Column(
+                  children: [
+                    const MyCircularImage(
+                        image: MyImages.user, width: 80, height: 80),
+                    TextButton(
+                      onPressed: () {},
+                      child: const Text('Change Profile Picture'),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
### Summary
Added profile picture section with 'Change Profile Picture' button to the ProfileScreen.

### What changed?
- Added a profile picture section in the `ProfileScreen`.
- Included a circular image widget for displaying the profile picture.
- Added a button for changing the profile picture.
- Used padding to create spacing around the profile picture section.

### How to test?
1. Navigate to the ProfileScreen.
2. Verify the presence of the profile picture section.
3. Check for the 'Change Profile Picture' button below the profile picture.

### Why make this change?
This change enhances the user experience by allowing users to view and update their profile picture directly from the ProfileScreen.

---

![photo_4974644943335304457_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/1d0f9462-db35-4d25-a495-cb0961cd6511.jpg)

