### PR TITLE
Product Detail Screen Route

### DIFF
--- a/lib/common/widgets/product/product_cards/product_card_vertical.dart
+++ b/lib/common/widgets/product/product_cards/product_card_vertical.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:iconsax/iconsax.dart';
 
 import 'package:mystore/common/styles/shadows.dart';
@@ -12,6 +13,7 @@ import 'package:mystore/utils/constants/colors.dart';
 import 'package:mystore/utils/constants/image_strings.dart';
 import 'package:mystore/utils/constants/sizes.dart';
 import 'package:mystore/utils/helpers/helper_functions.dart';
+import 'package:mystore/utils/navigation/go_routes.dart';
 
 class MyProductCardVertical extends StatelessWidget {
   const MyProductCardVertical({super.key});
@@ -21,7 +23,7 @@ class MyProductCardVertical extends StatelessWidget {
     final dark = MyHelperFunctions.isDarkMode(context);
 
     return GestureDetector(
-      onTap: () {},
+      onTap: () => context.pushNamed(MyRoutes.productDetail.name),
       child: Container(
         width: 180,
         padding: const EdgeInsets.all(1),

--- a/lib/features/shop/screens/product_details/product_detail.dart
+++ b/lib/features/shop/screens/product_details/product_detail.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:mystore/common/widgets/custom_shapes/curved_edges/curved_edges_widgets.dart';
+import 'package:mystore/utils/constants/colors.dart';
+import 'package:mystore/utils/constants/image_strings.dart';
+import 'package:mystore/utils/helpers/helper_functions.dart';
+
+class ProductDetailScreen extends StatelessWidget {
+  const ProductDetailScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = MyHelperFunctions.isDarkMode(context);
+    return Scaffold(
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            /// Product Image Slider
+            MyCurvedEdgeWidget(
+              child: Container(
+                color: dark ? MyColors.darkerGrey : MyColors.light,
+                child: Stack(
+                  children: [
+                    Image(image: AssetImage(MyImages.productImage1)),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/utils/navigation/go_routes.dart
+++ b/lib/utils/navigation/go_routes.dart
@@ -11,6 +11,7 @@ import 'package:mystore/features/authentication/screens/signup/verify_email.dart
 import 'package:mystore/features/personalization/screens/profile/profile.dart';
 import 'package:mystore/features/personalization/screens/settings/settings.dart';
 import 'package:mystore/features/shop/screens/home/home.dart';
+import 'package:mystore/features/shop/screens/product_details/product_detail.dart';
 import 'package:mystore/features/shop/screens/store/store.dart';
 import 'package:mystore/features/shop/screens/wishlist/wishlist.dart';
 import 'package:mystore/navigation_menu.dart';
@@ -28,6 +29,7 @@ enum MyRoutes {
   wishlist,
   settings,
   profile,
+  productDetail,
 }
 
 class AppRoute {
@@ -53,6 +55,7 @@ class AppRoute {
   static const String _wishlist = '/wishlist';
   static const String _settings = '/settings';
   static const String _profile = 'profile';
+  static const String _productDetail = 'product_detail';
 
   static final _routes = GoRouter(
     navigatorKey: _rootNavigatorKey,
@@ -107,6 +110,14 @@ class AppRoute {
             path: _home,
             name: MyRoutes.home.name,
             builder: (context, state) => const HomeScreen(),
+            routes: [
+              GoRoute(
+                path: _productDetail,
+                name: MyRoutes.productDetail.name,
+                parentNavigatorKey: _rootNavigatorKey,
+                builder: (context, state) => const ProductDetailScreen(),
+              ),
+            ],
           ),
           GoRoute(
             path: _store,


### PR DESCRIPTION
### Summary

Added a new ProductDetailScreen and implemented navigation to it from the product card.

### What changed?

- Created a new `ProductDetailScreen` with a basic layout including a product image slider.
- Updated `MyProductCardVertical` to navigate to the product detail screen when tapped.
- Added a new route for the product detail screen in `go_routes.dart`.

### How to test?

1. Navigate to the home screen.
2. Tap on any product card.
3. Verify that the app navigates to the new product detail screen.
4. Check that the product detail screen displays correctly with the image slider.

### Why make this change?

This change enhances the user experience by allowing users to view detailed information about a product. It's a crucial feature for any e-commerce application, enabling users to make informed decisions about their purchases.

---

![photo_5082551194873867648_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/d7635671-3fce-4b42-ab05-76a9797afec0.jpg)

