### PR TITLE
Color Attribute

### DIFF
--- a/lib/features/shop/screens/product_details/widgets/product_attribute.dart
+++ b/lib/features/shop/screens/product_details/widgets/product_attribute.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mystore/common/widgets/chips/choice_chip.dart';
 import 'package:mystore/common/widgets/custom_shapes/containers/rounded_container.dart';
 import 'package:mystore/common/widgets/texts/product_price_text.dart';
 import 'package:mystore/common/widgets/texts/product_title_text.dart';
@@ -70,7 +71,7 @@ class ProductAttribute extends StatelessWidget {
               ),
 
               /// Variation Description
-              MyProductTitleText(
+              const MyProductTitleText(
                 title:
                     'This is the Description of the Product and it can go upto max 4 lines',
                 smallSize: true,
@@ -78,6 +79,36 @@ class ProductAttribute extends StatelessWidget {
               ),
             ],
           ),
+        ),
+        const SizedBox(height: MySizes.spaceBtwItems),
+
+        /// Attributes
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const MySectionHeading(title: 'Colors', showActionButton: false),
+            const SizedBox(height: MySizes.spaceBtwItems / 2),
+            Wrap(
+              spacing: 8,
+              children: [
+                MyChoiceChip(
+                  text: 'Green',
+                  selected: false,
+                  onSelected: (value) {},
+                ),
+                MyChoiceChip(
+                  text: 'Blue',
+                  selected: false,
+                  onSelected: (value) {},
+                ),
+                MyChoiceChip(
+                  text: 'Yellow',
+                  selected: false,
+                  onSelected: (value) {},
+                ),
+              ],
+            ),
+          ],
         ),
       ],
     );


### PR DESCRIPTION
### Summary

Added color selection functionality to the product details screen.

### What changed?

- Imported the `MyChoiceChip` widget from the common widgets directory.
- Added a new section for color selection in the `ProductAttribute` widget.
- Implemented a `Column` widget to display color options using `MyChoiceChip` components.
- Included a "Colors" heading using `MySectionHeading`.
- Added spacing between the existing product description and the new color selection section.

### How to test?

1. Navigate to the product details screen.
2. Scroll down to find the new "Colors" section.
3. Verify that three color options (Green, Blue, Yellow) are displayed as selectable chips.
4. Tap on each color chip to ensure they are interactive, although the selection state is not yet implemented.

### Why make this change?

This change enhances the product details screen by allowing users to view and potentially select different color options for the product. It improves the overall user experience by providing more detailed product information and customization options, which can lead to better-informed purchasing decisions.

---

![photo_5082551194873867641_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/37dbb13d-2a07-460b-b9ec-ce1c58f4bac3.jpg)

