### PR TITLE
Sizes Attribute

### DIFF
--- a/lib/features/shop/screens/product_details/widgets/product_attribute.dart
+++ b/lib/features/shop/screens/product_details/widgets/product_attribute.dart
@@ -110,6 +110,34 @@ class ProductAttribute extends StatelessWidget {
             ),
           ],
         ),
+
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const MySectionHeading(title: 'Sizes', showActionButton: false),
+            const SizedBox(height: MySizes.spaceBtwItems / 2),
+            Wrap(
+              spacing: 8,
+              children: [
+                MyChoiceChip(
+                  text: 'EU 34',
+                  selected: false,
+                  onSelected: (value) {},
+                ),
+                MyChoiceChip(
+                  text: 'EU 36',
+                  selected: false,
+                  onSelected: (value) {},
+                ),
+                MyChoiceChip(
+                  text: 'EU 38',
+                  selected: false,
+                  onSelected: (value) {},
+                ),
+              ],
+            ),
+          ],
+        ),
       ],
     );
   }


### PR DESCRIPTION
### Summary

Added a size selection feature to the product details screen.

### What changed?

- Introduced a new "Sizes" section in the ProductAttribute widget.
- Implemented a Wrap widget containing MyChoiceChip components for different EU sizes (34, 36, 38).
- Added a MySectionHeading for the "Sizes" title.

### How to test?

1. Navigate to the product details screen.
2. Scroll to the newly added "Sizes" section.
3. Verify that the size options (EU 34, EU 36, EU 38) are displayed as selectable chips.
4. Tap on each size chip to ensure they are interactive (although functionality is not yet implemented).

### Why make this change?

This change enhances the product details screen by allowing users to view and potentially select different sizes for the product. It improves the user experience by providing more detailed product information and lays the groundwork for implementing size selection functionality in the future.

---

![photo_5082551194873867640_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/a375a567-90a6-465f-8b56-dbd71ee50c24.jpg)

