### PR TITLE
Add dependencies

### DIFF
--- a/.dart_tool/package_config.json
+++ b/.dart_tool/package_config.json
@@ -518,6 +518,12 @@
       "languageVersion": "3.0"
     },
     {
+      "name": "readmore",
+      "rootUri": "file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/readmore-3.0.0",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
       "name": "recase",
       "rootUri": "file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/recase-4.1.0",
       "packageUri": "lib/",
@@ -740,7 +746,7 @@
       "languageVersion": "3.4"
     }
   ],
-  "generated": "2024-07-29T18:53:15.343847Z",
+  "generated": "2024-07-29T18:57:30.145015Z",
   "generator": "pub",
   "generatorVersion": "3.4.3",
   "flutterRoot": "file:///D:/flutter_windows_3.13.7-stable/flutter",

--- a/.dart_tool/package_config_subset
+++ b/.dart_tool/package_config_subset
@@ -330,6 +330,10 @@ pubspec_parse
 3.0
 file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/pubspec_parse-1.3.0/
 file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/pubspec_parse-1.3.0/lib/
+readmore
+3.0
+file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/readmore-3.0.0/
+file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/readmore-3.0.0/lib/
 recase
 2.12
 file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/recase-4.1.0/

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -680,6 +680,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  readmore:
+    dependency: "direct main"
+    description:
+      name: readmore
+      sha256: e8fca2bd397b86342483b409e2ec26f06560a5963aceaa39b27f30722b506187
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   recase:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,6 @@ dependencies:
   injectable: ^2.4.2
   url_launcher: ^6.3.0
   path_provider: ^2.1.3
-  carousel_slider: ^4.2.1
   flutter_native_splash: ^2.4.1
   smooth_page_indicator: ^1.1.0
 
@@ -34,7 +33,9 @@ dependencies:
   flutter_bloc: ^8.1.6
   isar_flutter_libs: ^3.1.0+1
 
-# Product Specific
+  # Product Specific
+  readmore: ^3.0.0
+  carousel_slider: ^4.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Summary

Added the 'readmore' package to the project dependencies.

### What changed?

- Added 'readmore' package version 3.0.0 to the pubspec.yaml file under dependencies.
- Updated pubspec.lock to include the new 'readmore' package.
- Modified package configuration files to reflect the addition of the new package.

### How to test?

1. Run `flutter pub get` to ensure the new package is properly downloaded and integrated.
2. Check if the 'readmore' package is available for use in the project by trying to import it in a Dart file:
   ```dart
   import 'package:readmore/readmore.dart';
   ```
3. Implement a basic usage of the ReadMore widget in a test file to confirm it's working as expected.

### Why make this change?

The 'readmore' package provides a widget for truncating long text with a "Read more" / "Read less" functionality. This addition will enhance the user experience by allowing for more compact text displays with the option to expand when needed, particularly useful for handling long descriptions or content in the app.

---

![photo_5082551194873867639_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/121e7850-61dd-449e-808b-6efe9ae96361.jpg)

