### PR TITLE
Bottom Add To Cart Widget

### DIFF
--- a/lib/features/shop/screens/product_details/product_detail.dart
+++ b/lib/features/shop/screens/product_details/product_detail.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:iconsax/iconsax.dart';
+import 'package:mystore/features/shop/screens/product_details/widgets/bottom_add_to_cart_widget.dart';
 
 import 'package:readmore/readmore.dart';
 
@@ -16,6 +17,7 @@ class ProductDetailScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      bottomNavigationBar: const BottomAddToCart(),
       body: SingleChildScrollView(
         child: Column(
           children: [
@@ -35,6 +37,7 @@ class ProductDetailScreen extends StatelessWidget {
 
                   /// Price, Title, Stock & Brand
                   const ProductMetaData(),
+                  const SizedBox(height: MySizes.spaceBtwItems),
 
                   /// Attributes
                   const ProductAttribute(),

--- a/lib/features/shop/screens/product_details/widgets/bottom_add_to_cart_widget.dart
+++ b/lib/features/shop/screens/product_details/widgets/bottom_add_to_cart_widget.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:iconsax/iconsax.dart';
+import 'package:mystore/common/widgets/icons/circular_icon.dart';
+import 'package:mystore/utils/constants/colors.dart';
+import 'package:mystore/utils/constants/sizes.dart';
+import 'package:mystore/utils/helpers/helper_functions.dart';
+
+class BottomAddToCart extends StatelessWidget {
+  const BottomAddToCart({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = MyHelperFunctions.isDarkMode(context);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: MySizes.defaultSpace,
+        vertical: MySizes.defaultSpace / 2,
+      ),
+      decoration: BoxDecoration(
+        color: dark ? MyColors.darkerGrey : MyColors.light,
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(MySizes.cardRadiusLg),
+          topRight: Radius.circular(MySizes.cardRadiusLg),
+        ),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Row(
+            children: [
+              const MyCircularIcon(
+                icon: Iconsax.minus,
+                backgroundColor: MyColors.darkGrey,
+                width: 40,
+                height: 40,
+                color: MyColors.white,
+              ),
+              const SizedBox(width: MySizes.spaceBtwItems),
+              Text('2', style: Theme.of(context).textTheme.titleSmall),
+              const SizedBox(width: MySizes.spaceBtwItems),
+              const MyCircularIcon(
+                icon: Iconsax.add,
+                backgroundColor: MyColors.black,
+                width: 40,
+                height: 40,
+                color: MyColors.white,
+              ),
+            ],
+          ),
+          ElevatedButton(
+            onPressed: () {},
+            style: ElevatedButton.styleFrom(
+              padding: const EdgeInsets.all(MySizes.md),
+              backgroundColor: MyColors.black,
+              side: const BorderSide(color: MyColors.black),
+            ),
+            child: const Text('Add to Cart'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/shop/screens/product_details/widgets/product_attribute.dart
+++ b/lib/features/shop/screens/product_details/widgets/product_attribute.dart
@@ -98,7 +98,7 @@ class ProductAttribute extends StatelessWidget {
                 ),
                 MyChoiceChip(
                   text: 'Blue',
-                  selected: false,
+                  selected: true,
                   onSelected: (value) {},
                 ),
                 MyChoiceChip(
@@ -110,6 +110,7 @@ class ProductAttribute extends StatelessWidget {
             ),
           ],
         ),
+        const SizedBox(height: MySizes.spaceBtwItems),
 
         Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -121,7 +122,7 @@ class ProductAttribute extends StatelessWidget {
               children: [
                 MyChoiceChip(
                   text: 'EU 34',
-                  selected: false,
+                  selected: true,
                   onSelected: (value) {},
                 ),
                 MyChoiceChip(


### PR DESCRIPTION
### Summary

Added a bottom add-to-cart widget to the product detail screen and made minor UI adjustments.

### What changed?

- Introduced a new `BottomAddToCart` widget for the product detail screen
- Added the `BottomAddToCart` widget to the `ProductDetailScreen`
- Adjusted spacing in the product attributes section
- Updated the default selected color to blue and size to EU 34

### How to test?

1. Navigate to the product detail screen
2. Verify the new bottom add-to-cart widget is visible and functional
3. Check that the blue color and EU 34 size are pre-selected in the attributes section
4. Confirm proper spacing between different sections of the product details

### Why make this change?

This change enhances the user experience by providing an easily accessible add-to-cart functionality directly on the product detail screen. It also improves the visual layout and pre-selects common options to streamline the purchasing process for users.

---

![photo_5082551194873867635_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/b522962d-2709-4207-bb80-849ab6f07bf0.jpg)

![photo_5082551194873867634_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/f8c70b31-47d8-4202-ade0-69bea9089f95.jpg)



