### PR TITLE
Product Reviews Screen Route

### DIFF
--- a/lib/features/shop/screens/product_details/product_detail.dart
+++ b/lib/features/shop/screens/product_details/product_detail.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:iconsax/iconsax.dart';
 import 'package:mystore/features/shop/screens/product_details/widgets/bottom_add_to_cart_widget.dart';
+import 'package:mystore/utils/navigation/go_routes.dart';
 
 import 'package:readmore/readmore.dart';
 
@@ -83,7 +85,9 @@ class ProductDetailScreen extends StatelessWidget {
                         showActionButton: false,
                       ),
                       IconButton(
-                        onPressed: () {},
+                        onPressed: () {
+                          context.goNamed(MyRoutes.productReviews.name);
+                        },
                         icon: const Icon(Iconsax.arrow_right_3, size: 18),
                       ),
                     ],

--- a/lib/features/shop/screens/product_reviews/product_reviews.dart
+++ b/lib/features/shop/screens/product_reviews/product_reviews.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:mystore/common/widgets/appbar/appbar.dart';
+
+class ProductReviewsScreen extends StatelessWidget {
+  const ProductReviewsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: MyAppBar(
+        showBackArrow: true,
+        title: Text('Reviews & Ratings'),
+      ),
+      body: SingleChildScrollView(),
+    );
+  }
+}

--- a/lib/utils/navigation/go_routes.dart
+++ b/lib/utils/navigation/go_routes.dart
@@ -12,6 +12,7 @@ import 'package:mystore/features/personalization/screens/profile/profile.dart';
 import 'package:mystore/features/personalization/screens/settings/settings.dart';
 import 'package:mystore/features/shop/screens/home/home.dart';
 import 'package:mystore/features/shop/screens/product_details/product_detail.dart';
+import 'package:mystore/features/shop/screens/product_reviews/product_reviews.dart';
 import 'package:mystore/features/shop/screens/store/store.dart';
 import 'package:mystore/features/shop/screens/wishlist/wishlist.dart';
 import 'package:mystore/navigation_menu.dart';
@@ -30,6 +31,7 @@ enum MyRoutes {
   settings,
   profile,
   productDetail,
+  productReviews,
 }
 
 class AppRoute {
@@ -56,6 +58,7 @@ class AppRoute {
   static const String _settings = '/settings';
   static const String _profile = 'profile';
   static const String _productDetail = 'product_detail';
+  static const String _productReviews = 'product_reviews';
 
   static final _routes = GoRouter(
     navigatorKey: _rootNavigatorKey,
@@ -116,6 +119,14 @@ class AppRoute {
                 name: MyRoutes.productDetail.name,
                 parentNavigatorKey: _rootNavigatorKey,
                 builder: (context, state) => const ProductDetailScreen(),
+                routes: [
+                  GoRoute(
+                    path: _productReviews,
+                    name: MyRoutes.productReviews.name,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: (context, state) => const ProductReviewsScreen(),
+                  ),
+                ],
               ),
             ],
           ),


### PR DESCRIPTION
### Summary

Added a new Product Reviews screen and implemented navigation to it from the Product Detail screen.

### What changed?

- Created a new `ProductReviewsScreen` widget in `product_reviews.dart`
- Added a new route for Product Reviews in `go_routes.dart`
- Implemented navigation to the Product Reviews screen from the Product Detail screen

### How to test?

1. Navigate to the Product Detail screen
2. Tap on the arrow icon next to the "Reviews & Ratings" section
3. Verify that the app navigates to the new Product Reviews screen
4. Check that the app bar displays "Reviews & Ratings" and includes a back arrow

### Why make this change?

This change enhances the user experience by providing a dedicated screen for product reviews and ratings. It allows users to easily access and view detailed feedback about products, helping them make more informed purchasing decisions.

---

![photo_5082551194873867633_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/316aa47d-56d5-47b5-8225-85d21823edd9.jpg)

