### PR TITLE
User Address Screen Route

### DIFF
--- a/lib/features/personalization/screens/address/address.dart
+++ b/lib/features/personalization/screens/address/address.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+import 'package:iconsax/iconsax.dart';
+
+import 'package:mystore/common/widgets/appbar/appbar.dart';
+import 'package:mystore/utils/constants/colors.dart';
+
+class UserAddressScreen extends StatelessWidget {
+  const UserAddressScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {},
+        backgroundColor: MyColors.primary,
+        child: const Icon(
+          Iconsax.add,
+          color: MyColors.white,
+        ),
+      ),
+      appBar: MyAppBar(
+        showBackArrow: true,
+        title: Text(
+          'Addresses',
+          style: Theme.of(context).textTheme.headlineSmall,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/personalization/screens/settings/settings.dart
+++ b/lib/features/personalization/screens/settings/settings.dart
@@ -59,7 +59,9 @@ class SettingsScreen extends StatelessWidget {
                     icon: Iconsax.safe_home,
                     title: 'My Addresses',
                     subtitle: 'Set shopping delivery address',
-                    onTap: () {},
+                    onTap: () {
+                      context.goNamed(MyRoutes.address.name);
+                    },
                   ),
                   MySettingMenuTile(
                     icon: Iconsax.shopping_cart,

--- a/lib/utils/navigation/go_routes.dart
+++ b/lib/utils/navigation/go_routes.dart
@@ -8,6 +8,7 @@ import 'package:mystore/features/authentication/screens/password_configuration/f
 import 'package:mystore/features/authentication/screens/password_configuration/reset_password.dart';
 import 'package:mystore/features/authentication/screens/signup/signup.dart';
 import 'package:mystore/features/authentication/screens/signup/verify_email.dart';
+import 'package:mystore/features/personalization/screens/address/address.dart';
 import 'package:mystore/features/personalization/screens/profile/profile.dart';
 import 'package:mystore/features/personalization/screens/settings/settings.dart';
 import 'package:mystore/features/shop/screens/home/home.dart';
@@ -32,6 +33,7 @@ enum MyRoutes {
   profile,
   productDetail,
   productReviews,
+  address,
 }
 
 class AppRoute {
@@ -59,6 +61,7 @@ class AppRoute {
   static const String _profile = 'profile';
   static const String _productDetail = 'product_detail';
   static const String _productReviews = 'product_reviews';
+  static const String _address = 'address';
 
   static final _routes = GoRouter(
     navigatorKey: _rootNavigatorKey,
@@ -149,6 +152,12 @@ class AppRoute {
                 path: _profile,
                 name: MyRoutes.profile.name,
                 builder: (context, state) => const ProfileScreen(),
+              ),
+              GoRoute(
+                path: _address,
+                name: MyRoutes.address.name,
+                parentNavigatorKey: _rootNavigatorKey,
+                builder: (context, state) => const UserAddressScreen(),
               ),
             ],
           ),


### PR DESCRIPTION
### Summary

Added a new UserAddressScreen and integrated it into the app's navigation.

### What changed?

- Created a new `UserAddressScreen` in `address.dart`
- Updated the `SettingsScreen` to navigate to the new address screen
- Added a new route for the address screen in `go_routes.dart`

### How to test?

1. Navigate to the Settings screen
2. Tap on "My Addresses"
3. Verify that the new UserAddressScreen is displayed
4. Check that the app bar shows "Addresses" and includes a back arrow
5. Confirm the presence of a floating action button with a plus icon

### Why make this change?

This change introduces a dedicated screen for managing user addresses, enhancing the app's functionality and user experience. It allows users to view and potentially manage their shipping addresses directly within the app, improving the overall shopping and delivery process.

---

![photo_5082551194873867627_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/7e2a22ea-fb93-47c5-86cf-3c2a84d821b4.jpg)

