### PR TITLE
Single Address Card

### DIFF
--- a/lib/common/widgets/custom_shapes/containers/rounded_container.dart
+++ b/lib/common/widgets/custom_shapes/containers/rounded_container.dart
@@ -14,6 +14,7 @@ class MyRoundedContainer extends StatelessWidget {
     this.radius = MySizes.cardRadiusLg,
     this.backgroundColor = MyColors.white,
     this.borderColor = MyColors.borderPrimary,
+    this.roundedChild = true,
   });
 
   final double? width;
@@ -25,6 +26,7 @@ class MyRoundedContainer extends StatelessWidget {
   final Color backgroundColor;
   final EdgeInsetsGeometry? padding;
   final EdgeInsetsGeometry? margin;
+  final bool roundedChild;
 
   @override
   Widget build(BuildContext context) {
@@ -38,10 +40,12 @@ class MyRoundedContainer extends StatelessWidget {
         borderRadius: BorderRadius.circular(radius),
         border: showBorder ? Border.all(color: borderColor) : null,
       ),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(radius),
-        child: child,
-      ),
+      child: roundedChild
+          ? ClipRRect(
+              borderRadius: BorderRadius.circular(radius),
+              child: child,
+            )
+          : child,
     );
   }
 }

--- a/lib/features/personalization/screens/address/address.dart
+++ b/lib/features/personalization/screens/address/address.dart
@@ -3,7 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:iconsax/iconsax.dart';
 
 import 'package:mystore/common/widgets/appbar/appbar.dart';
+import 'package:mystore/features/personalization/screens/address/widgets/single_address.dart';
 import 'package:mystore/utils/constants/colors.dart';
+import 'package:mystore/utils/constants/sizes.dart';
 
 class UserAddressScreen extends StatelessWidget {
   const UserAddressScreen({super.key});
@@ -24,6 +26,17 @@ class UserAddressScreen extends StatelessWidget {
         title: Text(
           'Addresses',
           style: Theme.of(context).textTheme.headlineSmall,
+        ),
+      ),
+      body: const SingleChildScrollView(
+        child: Padding(
+          padding: EdgeInsets.all(MySizes.defaultSpace),
+          child: Column(
+            children: [
+              SingleAddress(selectedAddress: false),
+              SingleAddress(selectedAddress: true),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/personalization/screens/address/widgets/single_address.dart
+++ b/lib/features/personalization/screens/address/widgets/single_address.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+
+import 'package:iconsax/iconsax.dart';
+
+import 'package:mystore/common/widgets/custom_shapes/containers/rounded_container.dart';
+import 'package:mystore/utils/constants/colors.dart';
+import 'package:mystore/utils/constants/sizes.dart';
+import 'package:mystore/utils/helpers/helper_functions.dart';
+
+class SingleAddress extends StatelessWidget {
+  const SingleAddress({super.key, required this.selectedAddress});
+
+  final bool selectedAddress;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = MyHelperFunctions.isDarkMode(context);
+
+    return MyRoundedContainer(
+      showBorder: true,
+      roundedChild: false,
+      width: double.infinity,
+      padding: const EdgeInsets.all(MySizes.md),
+      backgroundColor: selectedAddress
+          ? MyColors.primary.withOpacity(0.5)
+          : Colors.transparent,
+      borderColor: selectedAddress
+          ? Colors.transparent
+          : dark
+              ? MyColors.darkerGrey
+              : MyColors.grey,
+      margin: const EdgeInsets.only(bottom: MySizes.spaceBtwItems),
+      child: Stack(
+        children: [
+          Positioned(
+            right: 5,
+            top: 0,
+            child: Icon(
+              selectedAddress ? Iconsax.tick_circle5 : null,
+              color: selectedAddress
+                  ? dark
+                      ? MyColors.light
+                      : MyColors.black
+                  : null,
+            ),
+          ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'John Doe',
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              const SizedBox(height: MySizes.sm / 2),
+              const Text(
+                '(+123) 456 7890',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: MySizes.sm / 2),
+              const Text(
+                '82356 Timmy Coves, South Liana, Maine, 87665, USA',
+                softWrap: true,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### Summary

Added a new SingleAddress widget and implemented it in the UserAddressScreen.

### What changed?

- Created a new `SingleAddress` widget to display individual address information.
- Updated `MyRoundedContainer` to include a `roundedChild` property for more flexible styling.
- Implemented the `SingleAddress` widget in the `UserAddressScreen`, displaying two address examples.

### How to test?

1. Navigate to the UserAddressScreen.
2. Verify that two address cards are displayed, one selected and one unselected.
3. Check that the selected address has a different background color and a tick icon.
4. Ensure the address information (name, phone, full address) is visible on each card.

### Why make this change?

This change improves the user interface for displaying and selecting addresses. It provides a clear visual distinction between selected and unselected addresses, making it easier for users to manage their address information within the app.

---

![photo_5082551194873867626_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/7d4931f9-7de6-4b61-ae85-9e95daaf73ea.jpg)

