### PR TITLE
New Address Screen Route

### DIFF
--- a/lib/features/personalization/screens/address/address.dart
+++ b/lib/features/personalization/screens/address/address.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:iconsax/iconsax.dart';
 
@@ -6,6 +7,7 @@ import 'package:mystore/common/widgets/appbar/appbar.dart';
 import 'package:mystore/features/personalization/screens/address/widgets/single_address.dart';
 import 'package:mystore/utils/constants/colors.dart';
 import 'package:mystore/utils/constants/sizes.dart';
+import 'package:mystore/utils/navigation/go_routes.dart';
 
 class UserAddressScreen extends StatelessWidget {
   const UserAddressScreen({super.key});
@@ -14,7 +16,9 @@ class UserAddressScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       floatingActionButton: FloatingActionButton(
-        onPressed: () {},
+        onPressed: () {
+          context.goNamed(MyRoutes.newAddress.name);
+        },
         backgroundColor: MyColors.primary,
         child: const Icon(
           Iconsax.add,

--- a/lib/features/personalization/screens/address/widgets/add_new_address.dart
+++ b/lib/features/personalization/screens/address/widgets/add_new_address.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:mystore/common/widgets/appbar/appbar.dart';
+
+class AddNewAddressScreen extends StatelessWidget {
+  const AddNewAddressScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: MyAppBar(showBackArrow: true, title: Text('Add new Address')),
+    );
+  }
+}

--- a/lib/utils/navigation/go_routes.dart
+++ b/lib/utils/navigation/go_routes.dart
@@ -9,6 +9,7 @@ import 'package:mystore/features/authentication/screens/password_configuration/r
 import 'package:mystore/features/authentication/screens/signup/signup.dart';
 import 'package:mystore/features/authentication/screens/signup/verify_email.dart';
 import 'package:mystore/features/personalization/screens/address/address.dart';
+import 'package:mystore/features/personalization/screens/address/widgets/add_new_address.dart';
 import 'package:mystore/features/personalization/screens/profile/profile.dart';
 import 'package:mystore/features/personalization/screens/settings/settings.dart';
 import 'package:mystore/features/shop/screens/home/home.dart';
@@ -34,6 +35,7 @@ enum MyRoutes {
   productDetail,
   productReviews,
   address,
+  newAddress
 }
 
 class AppRoute {
@@ -62,6 +64,7 @@ class AppRoute {
   static const String _productDetail = 'product_detail';
   static const String _productReviews = 'product_reviews';
   static const String _address = 'address';
+  static const String _newAddress = 'new_address';
 
   static final _routes = GoRouter(
     navigatorKey: _rootNavigatorKey,
@@ -158,6 +161,14 @@ class AppRoute {
                 name: MyRoutes.address.name,
                 parentNavigatorKey: _rootNavigatorKey,
                 builder: (context, state) => const UserAddressScreen(),
+                routes: [
+                  GoRoute(
+                    path: _newAddress,
+                    name: MyRoutes.newAddress.name,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: (context, state) => const AddNewAddressScreen(),
+                  ),
+                ],
               ),
             ],
           ),


### PR DESCRIPTION
### Summary

Added a new "Add New Address" screen and implemented navigation to it from the User Address screen.

### What changed?

- Created a new `AddNewAddressScreen` widget in `add_new_address.dart`
- Updated `UserAddressScreen` to navigate to the new address screen when the floating action button is pressed
- Added a new route `newAddress` in `go_routes.dart` for the Add New Address screen
- Imported necessary packages and updated route definitions

### How to test?

1. Navigate to the User Address screen
2. Tap the floating action button (+ icon)
3. Verify that the Add New Address screen opens with the correct title and back arrow

### Why make this change?

This change introduces the ability for users to add new addresses, enhancing the functionality of the address management feature in the app. It provides a dedicated screen for users to input new address details, improving the overall user experience and making the address management process more comprehensive.

---

![photo_5082551194873867625_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/05b4aa04-c7f3-4e77-8a20-cd08357afff8.jpg)

