### PR TITLE
New Address Form

### DIFF
--- a/lib/features/personalization/screens/address/widgets/add_new_address.dart
+++ b/lib/features/personalization/screens/address/widgets/add_new_address.dart
@@ -1,13 +1,99 @@
 import 'package:flutter/material.dart';
+
+import 'package:iconsax/iconsax.dart';
+
 import 'package:mystore/common/widgets/appbar/appbar.dart';
+import 'package:mystore/utils/constants/sizes.dart';
 
 class AddNewAddressScreen extends StatelessWidget {
   const AddNewAddressScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      appBar: MyAppBar(showBackArrow: true, title: Text('Add new Address')),
+    return Scaffold(
+      appBar:
+          const MyAppBar(showBackArrow: true, title: Text('Add new Address')),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(MySizes.defaultSpace),
+          child: Form(
+            child: Column(
+              children: [
+                TextFormField(
+                  decoration: const InputDecoration(
+                      prefixIcon: Icon(Iconsax.user), labelText: 'Name'),
+                ),
+                const SizedBox(height: MySizes.spaceBtwInputFields),
+                TextFormField(
+                  keyboardType: TextInputType.phone,
+                  decoration: const InputDecoration(
+                      prefixIcon: Icon(Iconsax.mobile),
+                      labelText: 'Phone Number'),
+                ),
+                const SizedBox(height: MySizes.spaceBtwInputFields),
+                Row(
+                  children: [
+                    Expanded(
+                      child: TextFormField(
+                        decoration: const InputDecoration(
+                          prefixIcon: Icon(Iconsax.building_31),
+                          labelText: 'Street',
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: MySizes.spaceBtwInputFields),
+                    Expanded(
+                      child: TextFormField(
+                        decoration: const InputDecoration(
+                          prefixIcon: Icon(Iconsax.code),
+                          labelText: 'Postal Code',
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: MySizes.spaceBtwInputFields),
+                Row(
+                  children: [
+                    Expanded(
+                      child: TextFormField(
+                        decoration: const InputDecoration(
+                          prefixIcon: Icon(Iconsax.building),
+                          labelText: 'City',
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: MySizes.spaceBtwInputFields),
+                    Expanded(
+                      child: TextFormField(
+                        decoration: const InputDecoration(
+                          prefixIcon: Icon(Iconsax.activity),
+                          labelText: 'State',
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: MySizes.spaceBtwInputFields),
+                TextFormField(
+                  decoration: const InputDecoration(
+                    prefixIcon: Icon(Iconsax.global),
+                    labelText: 'Country',
+                  ),
+                ),
+                const SizedBox(height: MySizes.defaultSpace),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: () {},
+                    child: const Text('Save'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
### Summary

Implemented the "Add New Address" screen UI with form fields for user input.

### What changed?

- Added a form with input fields for name, phone number, street, postal code, city, state, and country.
- Implemented a scrollable layout to accommodate all form fields.
- Added icons to each input field for better visual representation.
- Included a "Save" button at the bottom of the form.

### How to test?

1. Navigate to the "Add New Address" screen.
2. Verify that all form fields are present and correctly labeled.
3. Test the scrolling functionality to ensure all fields are accessible.
4. Check that the "Save" button is visible and clickable.
5. Ensure that the back arrow in the app bar functions correctly.

### Why make this change?

This change provides users with a comprehensive form to input their address details, improving the user experience when adding a new address to their profile. The structured layout and visual cues (icons) make it easier for users to understand and fill out the required information.

---

![photo_5082551194873867623_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/ada3d8e7-efb2-4345-a504-88b96bd4158c.jpg)

![photo_5082551194873867624_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/9259f6f1-6d13-4ba0-990b-0f8e35da70c4.jpg)

