### PR TITLE
Cart Screen Route

### DIFF
--- a/lib/features/shop/screens/cart/cart.dart
+++ b/lib/features/shop/screens/cart/cart.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+import 'package:mystore/common/widgets/appbar/appbar.dart';
+
+class CartScreen extends StatelessWidget {
+  const CartScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: MyAppBar(
+        showBackArrow: true,
+        title: Text(
+          'Cart',
+          style: Theme.of(context).textTheme.headlineSmall,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/shop/screens/home/widgets/home_appbar.dart
+++ b/lib/features/shop/screens/home/widgets/home_appbar.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
+
+import 'package:go_router/go_router.dart';
+
 import 'package:mystore/common/widgets/appbar/appbar.dart';
 import 'package:mystore/common/widgets/product/cart/cart_menu_icon.dart';
 import 'package:mystore/utils/constants/colors.dart';
 import 'package:mystore/utils/constants/text_strings.dart';
+import 'package:mystore/utils/navigation/go_routes.dart';
 
 class HomeAppBar extends StatelessWidget {
   const HomeAppBar({
@@ -34,7 +38,9 @@ class HomeAppBar extends StatelessWidget {
       actions: [
         MyCartCounterIcon(
           iconColor: MyColors.white,
-          onPressed: () {},
+          onPressed: () {
+            context.goNamed(MyRoutes.cart.name);
+          },
         ),
       ],
     );

--- a/lib/utils/navigation/go_routes.dart
+++ b/lib/utils/navigation/go_routes.dart
@@ -12,6 +12,7 @@ import 'package:mystore/features/personalization/screens/address/address.dart';
 import 'package:mystore/features/personalization/screens/address/widgets/add_new_address.dart';
 import 'package:mystore/features/personalization/screens/profile/profile.dart';
 import 'package:mystore/features/personalization/screens/settings/settings.dart';
+import 'package:mystore/features/shop/screens/cart/cart.dart';
 import 'package:mystore/features/shop/screens/home/home.dart';
 import 'package:mystore/features/shop/screens/product_details/product_detail.dart';
 import 'package:mystore/features/shop/screens/product_reviews/product_reviews.dart';
@@ -35,7 +36,8 @@ enum MyRoutes {
   productDetail,
   productReviews,
   address,
-  newAddress
+  newAddress,
+  cart,
 }
 
 class AppRoute {
@@ -65,6 +67,7 @@ class AppRoute {
   static const String _productReviews = 'product_reviews';
   static const String _address = 'address';
   static const String _newAddress = 'new_address';
+  static const String _cart = 'cart';
 
   static final _routes = GoRouter(
     navigatorKey: _rootNavigatorKey,
@@ -133,6 +136,12 @@ class AppRoute {
                     builder: (context, state) => const ProductReviewsScreen(),
                   ),
                 ],
+              ),
+              GoRoute(
+                path: _cart,
+                name: MyRoutes.cart.name,
+                parentNavigatorKey: _rootNavigatorKey,
+                builder: (context, state) => const CartScreen(),
               ),
             ],
           ),


### PR DESCRIPTION
### Summary

Added a new CartScreen and implemented navigation to it from the home screen.

### What changed?

- Created a new `CartScreen` widget in `cart.dart`
- Updated `HomeAppBar` to navigate to the cart screen when the cart icon is pressed
- Added a new route for the cart screen in `go_routes.dart`

### How to test?

1. Launch the app and navigate to the home screen
2. Tap the cart icon in the app bar
3. Verify that the app navigates to the new cart screen
4. Check that the cart screen displays correctly with the "Cart" title in the app bar

### Why make this change?

This change introduces a crucial feature for an e-commerce app - the ability to view and manage items in the shopping cart. By adding the cart screen and implementing navigation to it, we improve the user experience and provide a foundation for future cart-related functionality.

---

![photo_5082551194873867622_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/46ba9e20-9abe-41bc-93a9-e481b2e1e69a.jpg)

