### PR TITLE
Cart Item Widget

### DIFF
--- a/lib/common/widgets/product/cart/cart_item.dart
+++ b/lib/common/widgets/product/cart/cart_item.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+
+import 'package:mystore/common/widgets/images/rounded_image.dart';
+import 'package:mystore/common/widgets/texts/brand_title_text_with_verified_icon.dart';
+import 'package:mystore/common/widgets/texts/product_title_text.dart';
+import 'package:mystore/utils/constants/colors.dart';
+import 'package:mystore/utils/constants/image_strings.dart';
+import 'package:mystore/utils/constants/sizes.dart';
+import 'package:mystore/utils/helpers/helper_functions.dart';
+
+class MyCartItem extends StatelessWidget {
+  const MyCartItem({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        /// Image
+        MyRoundedImage(
+          imageUrl: MyImages.productImage1,
+          width: 60,
+          height: 60,
+          padding: const EdgeInsets.all(MySizes.sm),
+          backgroundColor: MyHelperFunctions.isDarkMode(context)
+              ? MyColors.darkerGrey
+              : MyColors.light,
+        ),
+        const SizedBox(width: MySizes.spaceBtwItems),
+
+        /// Title, Price & Size
+        Expanded(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const MyBrandTitleWithVerifiedIcon(title: 'Close up'),
+              const Flexible(
+                child: MyProductTitleText(
+                  title: 'Futuristic Sneakers',
+                  maxLines: 1,
+                ),
+              ),
+
+              /// Attributes
+              Text.rich(
+                TextSpan(
+                  children: [
+                    TextSpan(
+                      text: 'Color ',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    TextSpan(
+                      text: 'Grey ',
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+                    TextSpan(
+                      text: 'Size ',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    TextSpan(
+                      text: 'EU 38 ',
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/shop/screens/cart/cart.dart
+++ b/lib/features/shop/screens/cart/cart.dart
@@ -1,6 +1,14 @@
 import 'package:flutter/material.dart';
 
 import 'package:mystore/common/widgets/appbar/appbar.dart';
+import 'package:mystore/common/widgets/images/rounded_image.dart';
+import 'package:mystore/common/widgets/product/cart/cart_item.dart';
+import 'package:mystore/common/widgets/texts/brand_title_text_with_verified_icon.dart';
+import 'package:mystore/common/widgets/texts/product_title_text.dart';
+import 'package:mystore/utils/constants/colors.dart';
+import 'package:mystore/utils/constants/image_strings.dart';
+import 'package:mystore/utils/constants/sizes.dart';
+import 'package:mystore/utils/helpers/helper_functions.dart';
 
 class CartScreen extends StatelessWidget {
   const CartScreen({super.key});
@@ -13,6 +21,25 @@ class CartScreen extends StatelessWidget {
         title: Text(
           'Cart',
           style: Theme.of(context).textTheme.headlineSmall,
+        ),
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(MySizes.defaultSpace),
+          child: ListView.separated(
+            shrinkWrap: true,
+            itemCount: 4,
+            separatorBuilder: (_, __) => const SizedBox(
+              height: MySizes.spaceBtwSections,
+            ),
+            itemBuilder: (context, index) {
+              return Column(
+                children: [
+                  MyCartItem(),
+                ],
+              );
+            },
+          ),
         ),
       ),
     );


### PR DESCRIPTION
### Summary

Added a new cart item widget and implemented it in the cart screen.

### What changed?

- Created a new `MyCartItem` widget in `cart_item.dart` to display individual cart items.
- Updated the `CartScreen` in `cart.dart` to use the new `MyCartItem` widget.
- The cart item displays product image, brand, title, color, and size.

### How to test?

1. Navigate to the cart screen in the app.
2. Verify that cart items are displayed with the correct layout and information.
3. Check if the scrolling behavior works as expected with multiple items.

### Why make this change?

This change improves the user experience by providing a structured and visually appealing way to display cart items. It also enhances code modularity by separating the cart item widget, making it easier to maintain and reuse across the app.

---

![photo_5082551194873867621_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/e3fab496-749d-4337-af46-381ac03a1c28.jpg)

