### PR TITLE
Product Quatity With Add Remove Button Widget

### DIFF
--- a/lib/common/widgets/product/cart/add_remove_button.dart
+++ b/lib/common/widgets/product/cart/add_remove_button.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+import 'package:iconsax/iconsax.dart';
+
+import 'package:mystore/common/widgets/icons/circular_icon.dart';
+import 'package:mystore/utils/constants/colors.dart';
+import 'package:mystore/utils/constants/sizes.dart';
+import 'package:mystore/utils/helpers/helper_functions.dart';
+
+class MyProductQuatityWithAddRemoveButton extends StatelessWidget {
+  const MyProductQuatityWithAddRemoveButton({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        /// Add Remove Buttons
+        MyCircularIcon(
+          icon: Iconsax.minus,
+          width: 32,
+          height: 32,
+          size: MySizes.md,
+          color: MyHelperFunctions.isDarkMode(context)
+              ? MyColors.white
+              : MyColors.black,
+          backgroundColor: MyHelperFunctions.isDarkMode(context)
+              ? MyColors.darkGrey
+              : MyColors.light,
+        ),
+
+        const SizedBox(width: MySizes.spaceBtwItems),
+        Text('2', style: Theme.of(context).textTheme.titleSmall),
+        const SizedBox(width: MySizes.spaceBtwItems),
+
+        const MyCircularIcon(
+          icon: Iconsax.add,
+          width: 32,
+          height: 32,
+          size: MySizes.md,
+          color: MyColors.white,
+          backgroundColor: MyColors.primary,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/shop/screens/cart/cart.dart
+++ b/lib/features/shop/screens/cart/cart.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:iconsax/iconsax.dart';
 
 import 'package:mystore/common/widgets/appbar/appbar.dart';
+import 'package:mystore/common/widgets/icons/circular_icon.dart';
 import 'package:mystore/common/widgets/images/rounded_image.dart';
+import 'package:mystore/common/widgets/product/cart/add_remove_button.dart';
 import 'package:mystore/common/widgets/product/cart/cart_item.dart';
 import 'package:mystore/common/widgets/texts/brand_title_text_with_verified_icon.dart';
 import 'package:mystore/common/widgets/texts/product_title_text.dart';
@@ -36,6 +39,13 @@ class CartScreen extends StatelessWidget {
               return Column(
                 children: [
                   MyCartItem(),
+                  SizedBox(height: MySizes.spaceBtwItems),
+                  Row(
+                    children: [
+                      const SizedBox(width: 70),
+                      MyProductQuatityWithAddRemoveButton(),
+                    ],
+                  ),
                 ],
               );
             },


### PR DESCRIPTION
### Summary

Added a new widget for product quantity control and integrated it into the cart screen.

### What changed?

- Created a new file `add_remove_button.dart` with a `MyProductQuatityWithAddRemoveButton` widget.
- This widget includes circular icons for adding and removing items, along with a quantity display.
- Updated the `CartScreen` in `cart.dart` to include the new quantity control widget below each cart item.

### How to test?

1. Navigate to the cart screen in the app.
2. Verify that each cart item now has a quantity control widget below it.
3. Test the functionality of the add and remove buttons to ensure they update the quantity display.
4. Check that the widget adapts correctly to both light and dark modes.

### Why make this change?

This change enhances the user experience in the cart by providing an intuitive way to adjust product quantities. It allows users to easily increase or decrease the number of items they want to purchase without leaving the cart screen, streamlining the shopping process.

---

![photo_5082551194873867620_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/42ff7773-8781-494f-8515-392015bf626c.jpg)

