### PR TITLE
Checkout Button

### DIFF
--- a/lib/features/shop/screens/checkout/checkout.dart
+++ b/lib/features/shop/screens/checkout/checkout.dart
@@ -63,6 +63,15 @@ class CheckoutScreen extends StatelessWidget {
           ),
         ),
       ),
+
+      /// Checkout Button
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.all(MySizes.defaultSpace),
+        child: ElevatedButton(
+          onPressed: () {},
+          child: const Text('Checkout \$256.0'),
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
### Summary

Added a checkout button to the bottom of the checkout screen.

### What changed?

Implemented a new `bottomNavigationBar` in the `CheckoutScreen` widget. This includes an `ElevatedButton` with the text "Checkout $256.0" and a placeholder `onPressed` function.

### How to test?

1. Navigate to the checkout screen in the app.
2. Verify that a new button appears at the bottom of the screen.
3. Confirm that the button displays the text "Checkout $256.0".
4. Tap the button to ensure it's responsive (though no action is currently implemented).

### Why make this change?

This change enhances the user experience by providing a clear and accessible way for users to complete their purchase. The prominent checkout button at the bottom of the screen improves navigation and encourages users to finalize their transaction.

---

![photo_5082551194873867611_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/9b5a38fd-2b96-468e-aa8d-36301baef5d2.jpg)

