### PR TITLE
Orders Screen Route

### DIFF
--- a/lib/features/personalization/screens/settings/settings.dart
+++ b/lib/features/personalization/screens/settings/settings.dart
@@ -73,7 +73,9 @@ class SettingsScreen extends StatelessWidget {
                     icon: Iconsax.bag_tick,
                     title: 'My Orders',
                     subtitle: 'In-progress and Completed Orders',
-                    onTap: () {},
+                    onTap: () {
+                      context.goNamed(MyRoutes.orders.name);
+                    },
                   ),
                   MySettingMenuTile(
                     icon: Iconsax.bank,

--- a/lib/features/shop/screens/order/order.dart
+++ b/lib/features/shop/screens/order/order.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:mystore/common/widgets/appbar/appbar.dart';
+import 'package:mystore/utils/constants/sizes.dart';
+
+class OrderScreen extends StatelessWidget {
+  const OrderScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: MyAppBar(
+        showBackArrow: true,
+        title: Text(
+          'My Orders',
+          style: Theme.of(context).textTheme.headlineSmall,
+        ),
+      ),
+      body: const Padding(
+        padding: EdgeInsets.all(MySizes.defaultSpace),
+      ),
+    );
+  }
+}

--- a/lib/utils/navigation/go_routes.dart
+++ b/lib/utils/navigation/go_routes.dart
@@ -15,6 +15,7 @@ import 'package:mystore/features/personalization/screens/settings/settings.dart'
 import 'package:mystore/features/shop/screens/cart/cart.dart';
 import 'package:mystore/features/shop/screens/checkout/checkout.dart';
 import 'package:mystore/features/shop/screens/home/home.dart';
+import 'package:mystore/features/shop/screens/order/order.dart';
 import 'package:mystore/features/shop/screens/product_details/product_detail.dart';
 import 'package:mystore/features/shop/screens/product_reviews/product_reviews.dart';
 import 'package:mystore/features/shop/screens/store/store.dart';
@@ -40,6 +41,7 @@ enum MyRoutes {
   newAddress,
   cart,
   checkout,
+  orders,
 }
 
 class AppRoute {
@@ -71,6 +73,7 @@ class AppRoute {
   static const String _newAddress = 'new_address';
   static const String _cart = 'cart';
   static const String _checkout = 'checkout';
+  static const String _orders = 'orders';
 
   static final _routes = GoRouter(
     navigatorKey: _rootNavigatorKey,
@@ -175,6 +178,12 @@ class AppRoute {
                 path: _profile,
                 name: MyRoutes.profile.name,
                 builder: (context, state) => const ProfileScreen(),
+              ),
+              GoRoute(
+                path: _orders,
+                name: MyRoutes.orders.name,
+                parentNavigatorKey: _rootNavigatorKey,
+                builder: (context, state) => const OrderScreen(),
               ),
               GoRoute(
                 path: _address,


### PR DESCRIPTION
### Summary

Added a new Order screen and implemented navigation to it from the Settings screen.

### What changed?

- Created a new `OrderScreen` widget in `order.dart`
- Updated the `SettingsScreen` to navigate to the Order screen when tapping "My Orders"
- Added a new route for the Order screen in `go_routes.dart`

### How to test?

1. Navigate to the Settings screen
2. Tap on the "My Orders" option
3. Verify that the app navigates to the new Order screen
4. Check that the Order screen displays correctly with the "My Orders" title and back arrow

### Why make this change?

This change introduces a dedicated screen for users to view their orders, improving the overall user experience and providing a centralized location for order management. It enhances the app's functionality by allowing users to easily access and track their in-progress and completed orders.

---

![photo_5082551194873867608_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/462c907d-7a2a-4044-8329-ebe4ddfc975d.jpg)

