### PR TITLE
Subcategory Screen Route

### DIFF
--- a/lib/features/shop/screens/home/widgets/home_categories.dart
+++ b/lib/features/shop/screens/home/widgets/home_categories.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:mystore/common/widgets/image_text_widgets/vertical_image_text.dart';
 import 'package:mystore/utils/constants/image_strings.dart';
+import 'package:mystore/utils/navigation/go_routes.dart';
 
 class HomeCategories extends StatelessWidget {
   const HomeCategories({
@@ -20,7 +22,9 @@ class HomeCategories extends StatelessWidget {
           return MyVerticalImageText(
             title: 'Shoes',
             image: MyImages.shoeIcon,
-            onTap: () {},
+            onTap: () {
+              context.goNamed(MyRoutes.subCategory.name);
+            },
           );
         },
       ),

--- a/lib/features/shop/screens/sub_category/sub_categories.dart
+++ b/lib/features/shop/screens/sub_category/sub_categories.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:mystore/common/widgets/appbar/appbar.dart';
+import 'package:mystore/common/widgets/images/rounded_image.dart';
+import 'package:mystore/utils/constants/image_strings.dart';
+import 'package:mystore/utils/constants/sizes.dart';
+
+class SubCategoriesScreen extends StatelessWidget {
+  const SubCategoriesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: MyAppBar(title: Text('Sports sneakers'), showBackArrow: true),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: EdgeInsets.all(MySizes.defaultSpace),
+          child: Column(
+            children: [],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/utils/navigation/go_routes.dart
+++ b/lib/utils/navigation/go_routes.dart
@@ -19,6 +19,7 @@ import 'package:mystore/features/shop/screens/order/order.dart';
 import 'package:mystore/features/shop/screens/product_details/product_detail.dart';
 import 'package:mystore/features/shop/screens/product_reviews/product_reviews.dart';
 import 'package:mystore/features/shop/screens/store/store.dart';
+import 'package:mystore/features/shop/screens/sub_category/sub_categories.dart';
 import 'package:mystore/features/shop/screens/wishlist/wishlist.dart';
 import 'package:mystore/navigation_menu.dart';
 
@@ -42,6 +43,7 @@ enum MyRoutes {
   cart,
   checkout,
   orders,
+  subCategory,
 }
 
 class AppRoute {
@@ -74,6 +76,7 @@ class AppRoute {
   static const String _cart = 'cart';
   static const String _checkout = 'checkout';
   static const String _orders = 'orders';
+  static const String _subCategory = 'subCategory';
 
   static final _routes = GoRouter(
     navigatorKey: _rootNavigatorKey,
@@ -142,6 +145,12 @@ class AppRoute {
                     builder: (context, state) => const ProductReviewsScreen(),
                   ),
                 ],
+              ),
+              GoRoute(
+                path: _subCategory,
+                name: MyRoutes.subCategory.name,
+                parentNavigatorKey: _rootNavigatorKey,
+                builder: (context, state) => const SubCategoriesScreen(),
               ),
               GoRoute(
                 path: _cart,


### PR DESCRIPTION
### Summary

Added navigation to SubCategoriesScreen from HomeCategories and implemented the SubCategoriesScreen.

### What changed?

- Created a new SubCategoriesScreen with a basic structure
- Added navigation to SubCategoriesScreen when tapping on a category in HomeCategories
- Updated AppRoute to include the new SubCategoriesScreen route

### How to test?

1. Navigate to the home screen
2. Tap on the "Shoes" category
3. Verify that the SubCategoriesScreen opens with the title "Sports sneakers"
4. Check that the back arrow is present and functional

### Why make this change?

This change enhances the app's navigation structure by allowing users to explore subcategories within the main product categories. It improves the overall user experience by providing a more detailed and organized way to browse products.

---

![photo_5082551194873867606_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/6a652372-f5d8-4820-964e-1feb95218783.jpg)

