### PR TITLE
Subcategory Banner

### DIFF
--- a/lib/features/shop/screens/sub_category/sub_categories.dart
+++ b/lib/features/shop/screens/sub_category/sub_categories.dart
@@ -15,7 +15,15 @@ class SubCategoriesScreen extends StatelessWidget {
         child: Padding(
           padding: EdgeInsets.all(MySizes.defaultSpace),
           child: Column(
-            children: [],
+            children: [
+              /// Banner
+              MyRoundedImage(
+                width: double.infinity,
+                imageUrl: MyImages.promoBanner1,
+                applyImageRadius: true,
+              ),
+              const SizedBox(height: MySizes.spaceBtwSections),
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
### Summary

Added a promotional banner to the SubCategoriesScreen.

### What changed?

- Inserted a `MyRoundedImage` widget within the Column of the SubCategoriesScreen.
- Set the image to use `MyImages.promoBanner1` as the source.
- Applied image radius and set the width to occupy the full available space.
- Added a vertical spacing after the banner using `SizedBox`.

### How to test?

1. Navigate to the SubCategoriesScreen.
2. Verify that a promotional banner appears at the top of the screen.
3. Ensure the banner image fills the width of the screen and has rounded corners.
4. Check that there's appropriate spacing below the banner.

### Why make this change?

This change enhances the visual appeal of the SubCategoriesScreen by adding a promotional banner. It provides an opportunity to showcase featured items, deals, or announcements relevant to the subcategory, potentially increasing user engagement and conversions.

---

![photo_5082551194873867605_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/058eff5b-e9cf-49a5-8b65-23c05be45081.jpg)

