### PR TITLE
Product Card Horizontal

### DIFF
--- a/lib/common/widgets/product/product_cards/product_card_horizontal.dart
+++ b/lib/common/widgets/product/product_cards/product_card_horizontal.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:iconsax/iconsax.dart';
+import 'package:mystore/common/styles/shadows.dart';
+import 'package:mystore/common/widgets/custom_shapes/containers/rounded_container.dart';
+import 'package:mystore/common/widgets/icons/circular_icon.dart';
+import 'package:mystore/common/widgets/images/rounded_image.dart';
+import 'package:mystore/common/widgets/texts/brand_title_text_with_verified_icon.dart';
+import 'package:mystore/common/widgets/texts/product_price_text.dart';
+import 'package:mystore/common/widgets/texts/product_title_text.dart';
+import 'package:mystore/utils/constants/colors.dart';
+import 'package:mystore/utils/constants/image_strings.dart';
+import 'package:mystore/utils/constants/sizes.dart';
+import 'package:mystore/utils/helpers/helper_functions.dart';
+
+class MyProductCardHorizontal extends StatelessWidget {
+  const MyProductCardHorizontal({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = MyHelperFunctions.isDarkMode(context);
+
+    return Container(
+      width: 300,
+      padding: const EdgeInsets.all(1),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(MySizes.productImageRadius),
+        color: dark ? MyColors.darkerGrey : MyColors.softGrey,
+      ),
+      child: Row(
+        children: [
+          /// Thumbnail
+          MyRoundedContainer(
+            height: 120,
+            backgroundColor: dark ? MyColors.dark : MyColors.light,
+            child: Stack(
+              /// Thumbnail Image
+              children: [
+                // ignore: prefer_const_constructors
+                MyRoundedImage(
+                  imageUrl: MyImages.productImage1,
+                  fit: BoxFit.cover,
+                  applyImageRadius: true,
+                ),
+
+                /// Sale Tag
+                Positioned(
+                  top: 12,
+                  left: 4,
+                  child: MyRoundedContainer(
+                    radius: MySizes.sm,
+                    backgroundColor: MyColors.secondary.withOpacity(0.8),
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: MySizes.sm, vertical: MySizes.xs),
+                    child: Text(
+                      '25%',
+                      style: Theme.of(context)
+                          .textTheme
+                          .labelLarge!
+                          .apply(color: MyColors.black),
+                    ),
+                  ),
+                ),
+
+                /// Favourite Icon Button
+                const Positioned(
+                  top: 4,
+                  right: 4,
+                  child: MyCircularIcon(
+                    icon: Iconsax.heart5,
+                    color: Colors.red,
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          /// Details
+          SizedBox(
+            width: 180,
+            child: Padding(
+              padding: const EdgeInsets.only(top: MySizes.sm, left: MySizes.sm),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      MyProductTitleText(
+                          title: 'Futuristic Sneakers', smallSize: true),
+                      SizedBox(height: MySizes.spaceBtwItems / 2),
+                      MyBrandTitleWithVerifiedIcon(title: 'Close up'),
+                    ],
+                  ),
+                  Spacer(),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      /// Pricing
+                      Flexible(child: MyProductPriceText(price: '256.0')),
+
+                      /// Add to cart
+                      Container(
+                        decoration: BoxDecoration(
+                          color: MyColors.dark,
+                          borderRadius: BorderRadius.only(
+                            topLeft: Radius.circular(MySizes.cardRadiusMd),
+                            bottomRight:
+                                Radius.circular(MySizes.productImageRadius),
+                          ),
+                        ),
+                        child: const SizedBox(
+                          width: MySizes.iconLg * 1.2,
+                          height: MySizes.iconLg * 1.2,
+                          child: Center(
+                            child: Icon(Iconsax.add, color: MyColors.white),
+                          ),
+                        ),
+                      ),
+                    ],
+                  )
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/shop/screens/sub_category/sub_categories.dart
+++ b/lib/features/shop/screens/sub_category/sub_categories.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:mystore/common/widgets/appbar/appbar.dart';
 import 'package:mystore/common/widgets/images/rounded_image.dart';
+import 'package:mystore/common/widgets/product/product_cards/product_card_horizontal.dart';
+import 'package:mystore/common/widgets/texts/section_heading.dart';
 import 'package:mystore/utils/constants/image_strings.dart';
 import 'package:mystore/utils/constants/sizes.dart';
 
@@ -10,19 +12,45 @@ class SubCategoriesScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: MyAppBar(title: Text('Sports sneakers'), showBackArrow: true),
+      appBar: const MyAppBar(title: Text('Sports'), showBackArrow: true),
       body: SingleChildScrollView(
         child: Padding(
-          padding: EdgeInsets.all(MySizes.defaultSpace),
+          padding: const EdgeInsets.all(MySizes.defaultSpace),
           child: Column(
             children: [
               /// Banner
-              MyRoundedImage(
+              const MyRoundedImage(
                 width: double.infinity,
                 imageUrl: MyImages.promoBanner1,
                 applyImageRadius: true,
               ),
               const SizedBox(height: MySizes.spaceBtwSections),
+
+              /// Sub-Categories
+              Column(
+                children: [
+                  /// Heading
+                  MySectionHeading(
+                    title: 'Sports sneakers',
+                    onPressed: () {},
+                  ),
+                  const SizedBox(height: MySizes.spaceBtwItems / 2),
+
+                  SizedBox(
+                    height: 120,
+                    child: ListView.separated(
+                      itemCount: 4,
+                      scrollDirection: Axis.horizontal,
+                      separatorBuilder: (context, index) => const SizedBox(
+                        width: MySizes.spaceBtwItems,
+                      ),
+                      itemBuilder: (context, index) {
+                        return const MyProductCardHorizontal();
+                      },
+                    ),
+                  ),
+                ],
+              ),
             ],
           ),
         ),


### PR DESCRIPTION
### Summary

Added a new horizontal product card widget and implemented it in the sub-categories screen.

### What changed?

- Created a new `MyProductCardHorizontal` widget in `product_card_horizontal.dart`
- Updated `SubCategoriesScreen` in `sub_categories.dart` to include:
  - A banner image
  - A section heading for "Sports sneakers"
  - A horizontal scrollable list of `MyProductCardHorizontal` widgets

### How to test?

1. Navigate to the sub-categories screen
2. Verify the banner image is displayed correctly
3. Check that the "Sports sneakers" section heading is visible
4. Scroll horizontally through the product cards
5. Ensure each product card displays:
   - Product image with sale tag and favorite icon
   - Product title, brand, and price
   - Add to cart button

### Why make this change?

This change enhances the user experience by providing a more visually appealing and informative product listing in the sub-categories screen. The horizontal product cards allow users to quickly browse through multiple products in a compact format, improving navigation and product discovery.

---

![photo_5082551194873867604_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/0e780a34-0d80-4a8f-afe0-38fb2aeb15b1.jpg)

