### PR TITLE
All Products Screen Route

### DIFF
--- a/lib/features/shop/screens/all_products/all_products.dart
+++ b/lib/features/shop/screens/all_products/all_products.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:mystore/common/widgets/appbar/appbar.dart';
+import 'package:mystore/utils/constants/sizes.dart';
+
+class AllProducts extends StatelessWidget {
+  const AllProducts({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: MyAppBar(title: Text('Popular Products'), showBackArrow: true),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: EdgeInsets.all(MySizes.defaultSpace),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/shop/screens/home/home.dart
+++ b/lib/features/shop/screens/home/home.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:mystore/common/widgets/custom_shapes/containers/primary_header_container.dart';
 import 'package:mystore/common/widgets/custom_shapes/containers/search_container.dart';
@@ -10,6 +11,7 @@ import 'package:mystore/features/shop/screens/home/widgets/home_categories.dart'
 import 'package:mystore/features/shop/screens/home/widgets/home_promo_slider.dart';
 import 'package:mystore/utils/constants/image_strings.dart';
 import 'package:mystore/utils/constants/sizes.dart';
+import 'package:mystore/utils/navigation/go_routes.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -71,7 +73,9 @@ class HomeScreen extends StatelessWidget {
                   /// Heading
                   MySectionHeading(
                     title: 'Popular Product',
-                    onPressed: () {},
+                    onPressed: () {
+                      context.goNamed(MyRoutes.allProducts.name);
+                    },
                   ),
                   const SizedBox(height: MySizes.spaceBtwItems),
 

--- a/lib/utils/navigation/go_routes.dart
+++ b/lib/utils/navigation/go_routes.dart
@@ -12,6 +12,7 @@ import 'package:mystore/features/personalization/screens/address/address.dart';
 import 'package:mystore/features/personalization/screens/address/widgets/add_new_address.dart';
 import 'package:mystore/features/personalization/screens/profile/profile.dart';
 import 'package:mystore/features/personalization/screens/settings/settings.dart';
+import 'package:mystore/features/shop/screens/all_products/all_products.dart';
 import 'package:mystore/features/shop/screens/cart/cart.dart';
 import 'package:mystore/features/shop/screens/checkout/checkout.dart';
 import 'package:mystore/features/shop/screens/home/home.dart';
@@ -44,6 +45,7 @@ enum MyRoutes {
   checkout,
   orders,
   subCategory,
+  allProducts,
 }
 
 class AppRoute {
@@ -77,6 +79,7 @@ class AppRoute {
   static const String _checkout = 'checkout';
   static const String _orders = 'orders';
   static const String _subCategory = 'subCategory';
+  static const String _allProducts = 'allProducts';
 
   static final _routes = GoRouter(
     navigatorKey: _rootNavigatorKey,
@@ -145,6 +148,12 @@ class AppRoute {
                     builder: (context, state) => const ProductReviewsScreen(),
                   ),
                 ],
+              ),
+              GoRoute(
+                path: _allProducts,
+                name: MyRoutes.allProducts.name,
+                parentNavigatorKey: _rootNavigatorKey,
+                builder: (context, state) => const AllProducts(),
               ),
               GoRoute(
                 path: _subCategory,


### PR DESCRIPTION
### Summary

Added a new "All Products" screen and linked it from the home screen.

### What changed?

- Created a new `AllProducts` widget in `all_products.dart`
- Updated the home screen to navigate to the new "All Products" screen when the "Popular Product" section heading is tapped
- Added a new route for the "All Products" screen in the app's navigation system

### How to test?

1. Launch the app and navigate to the home screen
2. Tap on the "Popular Product" section heading
3. Verify that the app navigates to the new "All Products" screen
4. Check that the "All Products" screen displays correctly with an app bar titled "Popular Products" and a back arrow

### Why make this change?

This change improves the app's navigation and user experience by providing a dedicated screen to view all popular products. It allows users to easily access and browse through the entire collection of popular items from the home screen.

---

![photo_5082551194873867603_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/6f96792a-ff18-46b9-bcf7-f5c4bdd2d809.jpg)

