### PR TITLE
All Products List

### DIFF
--- a/lib/features/shop/screens/all_products/all_products.dart
+++ b/lib/features/shop/screens/all_products/all_products.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:iconsax/iconsax.dart';
 import 'package:mystore/common/widgets/appbar/appbar.dart';
+import 'package:mystore/common/widgets/layouts/grid_layout.dart';
+import 'package:mystore/common/widgets/product/product_cards/product_card_vertical.dart';
 import 'package:mystore/utils/constants/sizes.dart';
 
 class AllProducts extends StatelessWidget {
@@ -9,10 +11,11 @@ class AllProducts extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: MyAppBar(title: Text('Popular Products'), showBackArrow: true),
+      appBar:
+          const MyAppBar(title: Text('Popular Products'), showBackArrow: true),
       body: SingleChildScrollView(
         child: Padding(
-          padding: EdgeInsets.all(MySizes.defaultSpace),
+          padding: const EdgeInsets.all(MySizes.defaultSpace),
           child: Column(
             children: [
               /// Dropdown
@@ -27,7 +30,13 @@ class AllProducts extends StatelessWidget {
                     .toList(),
                 onChanged: (value) {},
               ),
-              const SizedBox(height: MySizes.spaceBtwSections)
+              const SizedBox(height: MySizes.spaceBtwSections),
+
+              /// Products
+              MyGridLayout(
+                itemCount: 8,
+                itemBuilder: (_, index) => const MyProductCardVertical(),
+              ),
             ],
           ),
         ),


### PR DESCRIPTION
### Summary

Added product grid layout to the All Products screen.

### What changed?

- Imported necessary widgets: `MyGridLayout` and `MyProductCardVertical`.
- Added a `MyGridLayout` widget to display product cards in a grid format.
- Set the `itemCount` to 8 and used `MyProductCardVertical` for each item in the grid.
- Made minor adjustments to existing widgets, such as adding `const` modifiers.

### How to test?

1. Navigate to the All Products screen.
2. Verify that a grid of product cards is displayed below the dropdown menu.
3. Ensure that 8 product cards are visible in the grid layout.
4. Check that scrolling works properly to view all products.

### Why make this change?

This change enhances the All Products screen by implementing a grid layout for product display. It improves the user experience by providing a visually appealing and organized way to browse through multiple products, making it easier for users to scan and select items of interest.

---

![photo_5082551194873867601_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/ae216d3b-9714-4a81-a75c-3b13ab0a94dc.jpg)

