### PR TITLE
All Brand Screen Route

### DIFF
--- a/lib/features/shop/screens/brand/all_brand.dart
+++ b/lib/features/shop/screens/brand/all_brand.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:mystore/common/widgets/appbar/appbar.dart';
+import 'package:mystore/utils/constants/sizes.dart';
+
+class AllBrandsScreen extends StatelessWidget {
+  const AllBrandsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: MyAppBar(title: Text('Brand'), showBackArrow: true),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: EdgeInsets.all(MySizes.defaultSpace),
+          child: Column(
+            children: [],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/shop/screens/store/store.dart
+++ b/lib/features/shop/screens/store/store.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:mystore/common/widgets/appbar/appbar.dart';
 import 'package:mystore/common/widgets/appbar/tabbar.dart';
@@ -11,6 +12,7 @@ import 'package:mystore/features/shop/screens/store/widgets/category_tabs.dart';
 import 'package:mystore/utils/constants/colors.dart';
 import 'package:mystore/utils/constants/sizes.dart';
 import 'package:mystore/utils/helpers/helper_functions.dart';
+import 'package:mystore/utils/navigation/go_routes.dart';
 
 class StoreScreen extends StatelessWidget {
   const StoreScreen({super.key});
@@ -61,7 +63,9 @@ class StoreScreen extends StatelessWidget {
                       MySectionHeading(
                         title: 'Featured Brand',
                         showActionButton: true,
-                        onPressed: () {},
+                        onPressed: () {
+                          context.goNamed(MyRoutes.allBrands.name);
+                        },
                       ),
                       const SizedBox(height: MySizes.spaceBtwItems / 1.5),
 

--- a/lib/utils/navigation/go_routes.dart
+++ b/lib/utils/navigation/go_routes.dart
@@ -13,6 +13,7 @@ import 'package:mystore/features/personalization/screens/address/widgets/add_new
 import 'package:mystore/features/personalization/screens/profile/profile.dart';
 import 'package:mystore/features/personalization/screens/settings/settings.dart';
 import 'package:mystore/features/shop/screens/all_products/all_products.dart';
+import 'package:mystore/features/shop/screens/brand/all_brand.dart';
 import 'package:mystore/features/shop/screens/cart/cart.dart';
 import 'package:mystore/features/shop/screens/checkout/checkout.dart';
 import 'package:mystore/features/shop/screens/home/home.dart';
@@ -46,6 +47,7 @@ enum MyRoutes {
   orders,
   subCategory,
   allProducts,
+  allBrands,
 }
 
 class AppRoute {
@@ -80,6 +82,7 @@ class AppRoute {
   static const String _orders = 'orders';
   static const String _subCategory = 'subCategory';
   static const String _allProducts = 'allProducts';
+  static const String _allBrands = 'allBrands';
 
   static final _routes = GoRouter(
     navigatorKey: _rootNavigatorKey,
@@ -181,6 +184,14 @@ class AppRoute {
             path: _store,
             name: MyRoutes.store.name,
             builder: (context, state) => const StoreScreen(),
+            routes: [
+              GoRoute(
+                path: _allBrands,
+                name: MyRoutes.allBrands.name,
+                parentNavigatorKey: _rootNavigatorKey,
+                builder: (context, state) => const AllBrandsScreen(),
+              ),
+            ],
           ),
           GoRoute(
             path: _wishlist,


### PR DESCRIPTION
### Summary

Added a new AllBrandsScreen and implemented navigation to it from the StoreScreen.

### What changed?

- Created a new `AllBrandsScreen` widget in `all_brand.dart`
- Updated `StoreScreen` to navigate to the AllBrandsScreen when the "Featured Brand" action button is pressed
- Added a new route for AllBrandsScreen in `go_routes.dart`

### How to test?

1. Navigate to the StoreScreen
2. Tap on the action button next to "Featured Brand"
3. Verify that the AllBrandsScreen is displayed with the correct app bar title and back arrow

### Why make this change?

This change introduces a dedicated screen for displaying all brands, improving the user experience by providing a centralized location to browse and explore different brands available in the store.

---

![photo_5082551194873867598_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/2341ee4c-da9c-471f-a2fd-2d17d4ec41a0.jpg)

