### PR TITLE
Shops/Brands Screen

### DIFF
--- a/lib/common/widgets/product/sortable/sortable_products.dart
+++ b/lib/common/widgets/product/sortable/sortable_products.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+import 'package:iconsax/iconsax.dart';
+
+import 'package:mystore/common/widgets/layouts/grid_layout.dart';
+import 'package:mystore/common/widgets/product/product_cards/product_card_vertical.dart';
+import 'package:mystore/utils/constants/sizes.dart';
+
+class MySortableProducts extends StatelessWidget {
+  const MySortableProducts({
+    super.key,
+    
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        /// Dropdown
+        DropdownButtonFormField(
+          decoration: const InputDecoration(prefixIcon: Icon(Iconsax.sort)),
+          items: ['Name', 'Higher Price', 'Lower Price', 'Newest']
+              .map((option) => DropdownMenuItem(
+                    value: option,
+                    child: Text(option),
+                  ))
+              .toList(),
+          onChanged: (value) {},
+        ),
+        const SizedBox(height: MySizes.spaceBtwSections),
+
+        /// Products
+        MyGridLayout(
+          itemCount: 8,
+          itemBuilder: (_, index) => const MyProductCardVertical(),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/shop/screens/all_products/all_products.dart
+++ b/lib/features/shop/screens/all_products/all_products.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:iconsax/iconsax.dart';
+
 import 'package:mystore/common/widgets/appbar/appbar.dart';
-import 'package:mystore/common/widgets/layouts/grid_layout.dart';
-import 'package:mystore/common/widgets/product/product_cards/product_card_vertical.dart';
+import 'package:mystore/common/widgets/product/sortable/sortable_products.dart';
 import 'package:mystore/utils/constants/sizes.dart';
 
 class AllProducts extends StatelessWidget {
@@ -10,35 +9,12 @@ class AllProducts extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar:
-          const MyAppBar(title: Text('Popular Products'), showBackArrow: true),
+    return const Scaffold(
+      appBar: MyAppBar(title: Text('Popular Products'), showBackArrow: true),
       body: SingleChildScrollView(
         child: Padding(
-          padding: const EdgeInsets.all(MySizes.defaultSpace),
-          child: Column(
-            children: [
-              /// Dropdown
-              DropdownButtonFormField(
-                decoration:
-                    const InputDecoration(prefixIcon: Icon(Iconsax.sort)),
-                items: ['Name', 'Higher Price', 'Lower Price', 'Newest']
-                    .map((option) => DropdownMenuItem(
-                          value: option,
-                          child: Text(option),
-                        ))
-                    .toList(),
-                onChanged: (value) {},
-              ),
-              const SizedBox(height: MySizes.spaceBtwSections),
-
-              /// Products
-              MyGridLayout(
-                itemCount: 8,
-                itemBuilder: (_, index) => const MyProductCardVertical(),
-              ),
-            ],
-          ),
+          padding: EdgeInsets.all(MySizes.defaultSpace),
+          child: MySortableProducts(),
         ),
       ),
     );

--- a/lib/features/shop/screens/brand/all_brand.dart
+++ b/lib/features/shop/screens/brand/all_brand.dart
@@ -1,6 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mystore/common/widgets/appbar/appbar.dart';
+import 'package:mystore/common/widgets/brands/brand_card.dart';
+import 'package:mystore/common/widgets/layouts/grid_layout.dart';
+import 'package:mystore/common/widgets/texts/section_heading.dart';
 import 'package:mystore/utils/constants/sizes.dart';
+import 'package:mystore/utils/navigation/go_routes.dart';
 
 class AllBrandsScreen extends StatelessWidget {
   const AllBrandsScreen({super.key});
@@ -13,7 +18,25 @@ class AllBrandsScreen extends StatelessWidget {
         child: Padding(
           padding: EdgeInsets.all(MySizes.defaultSpace),
           child: Column(
-            children: [],
+            children: [
+              /// Heading
+              MySectionHeading(title: 'Brands', showActionButton: false),
+              SizedBox(height: MySizes.spaceBtwItems),
+
+              /// Brands
+              MyGridLayout(
+                itemCount: 10,
+                mainAxisExtent: 80,
+                itemBuilder: (_, index) {
+                  return MyBrandCard(
+                    showBorder: true,
+                    onTap: () {
+                      context.goNamed(MyRoutes.brandProducts.name);
+                    },
+                  );
+                },
+              )
+            ],
           ),
         ),
       ),

--- a/lib/features/shop/screens/brand/brand_products.dart
+++ b/lib/features/shop/screens/brand/brand_products.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:mystore/common/widgets/appbar/appbar.dart';
+import 'package:mystore/common/widgets/brands/brand_card.dart';
+import 'package:mystore/common/widgets/product/sortable/sortable_products.dart';
+import 'package:mystore/utils/constants/sizes.dart';
+
+class BrandProductsScreen extends StatelessWidget {
+  const BrandProductsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: MyAppBar(
+        showBackArrow: true,
+        title: Text('Close Up'),
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: EdgeInsets.all(MySizes.defaultSpace),
+          child: Column(
+            children: [
+              /// Brand Details
+              MyBrandCard(showBorder: true),
+              SizedBox(height: MySizes.spaceBtwSections),
+
+              MySortableProducts(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/utils/navigation/go_routes.dart
+++ b/lib/utils/navigation/go_routes.dart
@@ -14,6 +14,7 @@ import 'package:mystore/features/personalization/screens/profile/profile.dart';
 import 'package:mystore/features/personalization/screens/settings/settings.dart';
 import 'package:mystore/features/shop/screens/all_products/all_products.dart';
 import 'package:mystore/features/shop/screens/brand/all_brand.dart';
+import 'package:mystore/features/shop/screens/brand/brand_products.dart';
 import 'package:mystore/features/shop/screens/cart/cart.dart';
 import 'package:mystore/features/shop/screens/checkout/checkout.dart';
 import 'package:mystore/features/shop/screens/home/home.dart';
@@ -48,6 +49,7 @@ enum MyRoutes {
   subCategory,
   allProducts,
   allBrands,
+  brandProducts,
 }
 
 class AppRoute {
@@ -80,9 +82,10 @@ class AppRoute {
   static const String _cart = 'cart';
   static const String _checkout = 'checkout';
   static const String _orders = 'orders';
-  static const String _subCategory = 'subCategory';
-  static const String _allProducts = 'allProducts';
-  static const String _allBrands = 'allBrands';
+  static const String _subCategory = 'sub_category';
+  static const String _allProducts = 'all_products';
+  static const String _allBrands = 'all_brands';
+  static const String _brandProducts = 'brand_products';
 
   static final _routes = GoRouter(
     navigatorKey: _rootNavigatorKey,
@@ -190,6 +193,14 @@ class AppRoute {
                 name: MyRoutes.allBrands.name,
                 parentNavigatorKey: _rootNavigatorKey,
                 builder: (context, state) => const AllBrandsScreen(),
+                routes: [
+                  GoRoute(
+                    path: _brandProducts,
+                    name: MyRoutes.brandProducts.name,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: (context, state) => const BrandProductsScreen(),
+                  ),
+                ],
               ),
             ],
           ),


### PR DESCRIPTION
### Summary

Added sortable products feature and implemented brand-related screens.

### What changed?

- Created a new `MySortableProducts` widget for displaying sortable product lists
- Updated `AllProducts` screen to use the new `MySortableProducts` widget
- Implemented `AllBrandsScreen` with a grid layout of brand cards
- Added `BrandProductsScreen` to display products for a specific brand
- Updated navigation routes to include new brand-related screens

### How to test?

1. Navigate to the "All Products" screen and verify the sortable dropdown functionality
2. Go to the "All Brands" screen and check if brand cards are displayed correctly
3. Tap on a brand card to navigate to the "Brand Products" screen
4. Verify that the brand details and sortable products are displayed on the "Brand Products" screen

### Why make this change?

This change enhances the user experience by providing a more organized way to browse products and brands. It allows users to easily sort products and explore specific brand offerings, improving navigation and product discovery within the app.

---

![photo_5082551194873867597_y.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/FCaHMcBuQnYt0vu008Bn/06607c01-9109-4a06-b543-29444008185b.jpg)

