### PR TITLE
Add dependency formz

### DIFF
--- a/.dart_tool/package_config.json
+++ b/.dart_tool/package_config.json
@@ -290,6 +290,12 @@
       "languageVersion": "2.12"
     },
     {
+      "name": "formz",
+      "rootUri": "file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/formz-0.7.0",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
       "name": "freezed_annotation",
       "rootUri": "file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/freezed_annotation-2.4.4",
       "packageUri": "lib/",
@@ -860,7 +866,7 @@
       "languageVersion": "3.4"
     }
   ],
-  "generated": "2024-09-07T22:19:06.598643Z",
+  "generated": "2024-09-17T21:24:07.686618Z",
   "generator": "pub",
   "generatorVersion": "3.4.3",
   "flutterRoot": "file:///D:/flutter_windows_3.13.7-stable/flutter",

--- a/.dart_tool/package_config_subset
+++ b/.dart_tool/package_config_subset
@@ -178,6 +178,10 @@ fluttertoast
 2.12
 file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/fluttertoast-8.2.8/
 file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/fluttertoast-8.2.8/lib/
+formz
+3.0
+file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/formz-0.7.0/
+file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/formz-0.7.0/lib/
 freezed_annotation
 3.0
 file:///C:/Users/Ima/AppData/Local/Pub/Cache/hosted/pub.dev/freezed_annotation-2.4.4/

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -376,6 +376,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.2.8"
+  formz:
+    dependency: "direct main"
+    description:
+      name: formz
+      sha256: a58eb48d84685b7ffafac1d143bf47d585bf54c7db89fe81c175dfd6e53201c7
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0"
   freezed_annotation:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   # Utility Packages
   dio: ^5.5.0
   http: ^1.2.2
+  formz: ^0.7.0
   intl: ^0.19.0
   logger: ^2.3.0
   get_it: ^7.7.0


### PR DESCRIPTION
### Summary
Added the Formz package (v0.7.0) to handle form validation and state management.

### What changed?
Added the Formz package dependency to `pubspec.yaml` and updated related package configuration files.

### How to test?
1. Run `flutter pub get` to ensure the package is properly installed
2. Verify Formz package appears in your dependencies when running `flutter pub deps`
3. Confirm the project builds successfully

### Why make this change?
Formz provides a standardized approach to form validation and state management in Flutter applications. This package will help improve form handling, input validation, and maintain consistent form state across the application.