### PR TITLE
Local Shared Preferences Data Source

### DIFF
--- a/lib/core/local_storage/shared_preferences/shared_preferences_data_source.dart
+++ b/lib/core/local_storage/shared_preferences/shared_preferences_data_source.dart
@@ -1,0 +1,14 @@
+abstract class SharedPreferencesDataSource {
+  Future<void> saveString(String key, String value);
+  Future<void> saveBool(String key, bool value);
+  Future<void> saveInt(String key, int value);
+  Future<void> saveDouble(String key, double value);
+
+  Future<String> getString(String key);
+  Future<bool> getBool(String key);
+  Future<int> getInt(String key);
+  Future<double> getDouble(String key);
+
+  Future<void> remove(String key);
+  Future<void> clear();
+}

--- a/lib/core/local_storage/shared_preferences/shared_preferences_data_source_impl.dart
+++ b/lib/core/local_storage/shared_preferences/shared_preferences_data_source_impl.dart
@@ -1,0 +1,57 @@
+import 'package:injectable/injectable.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mystore/core/local_storage/shared_preferences/shared_preferences_data_source.dart';
+
+@LazySingleton(as: SharedPreferencesDataSource)
+class SharedPreferencesDataSourceImpl implements SharedPreferencesDataSource {
+  final SharedPreferences sharedPreferences;
+
+  SharedPreferencesDataSourceImpl(this.sharedPreferences);
+
+  @override
+  Future<void> clear() async => await sharedPreferences.clear();
+
+  @override
+  Future<void> remove(String key) async => await sharedPreferences.remove(key);
+
+  @override
+  Future<bool> getBool(String key) async {
+    return sharedPreferences.getBool(key) ?? false;
+  }
+
+  @override
+  Future<double> getDouble(String key) async {
+    return sharedPreferences.getDouble(key) ?? 0.0;
+  }
+
+  @override
+  Future<int> getInt(String key) async {
+    return sharedPreferences.getInt(key) ?? 0;
+  }
+
+  @override
+  Future<String> getString(String key) async {
+    return sharedPreferences.getString(key) ?? '';
+  }
+
+  @override
+  Future<void> saveBool(String key, bool value) async {
+    await sharedPreferences.setBool(key, value);
+  }
+
+  @override
+  Future<void> saveDouble(String key, double value) async {
+    await sharedPreferences.setDouble(key, value);
+  }
+
+  @override
+  Future<void> saveInt(String key, int value) async {
+    await sharedPreferences.setInt(key, value);
+  }
+
+  @override
+  Future<void> saveString(String key, String value) async {
+    await sharedPreferences.setString(key, value);
+  }
+}


### PR DESCRIPTION
### Summary
Added SharedPreferences data source implementation for local storage operations.

### What changed?
- Created abstract `SharedPreferencesDataSource` class defining methods for local storage operations
- Implemented `SharedPreferencesDataSourceImpl` with concrete implementations for saving and retrieving various data types
- Added support for storing and retrieving strings, booleans, integers, and doubles
- Included methods for clearing storage and removing specific keys

### How to test?
1. Initialize SharedPreferences instance
2. Test saving different data types using the implemented methods
3. Verify retrieved values match saved values
4. Test clear and remove functionality
5. Verify default values are returned when keys don't exist:
   - Empty string for getString
   - False for getBool
   - 0 for getInt
   - 0.0 for getDouble

### Why make this change?
To provide a standardized interface for local storage operations using SharedPreferences, making it easier to persist and retrieve data across app sessions while maintaining clean architecture principles through dependency injection.