### PR TITLE
Onboarding Repository

### DIFF
--- a/lib/core/repositories/onboarding/onboarding_repository.dart
+++ b/lib/core/repositories/onboarding/onboarding_repository.dart
@@ -1,0 +1,4 @@
+abstract class OnboardingRepository {
+  Future<void> setOnboardingCompleted(bool value);
+  Future<bool> isOnboardingCompleted();
+}

--- a/lib/core/repositories/onboarding/onboarding_repository_impl.dart
+++ b/lib/core/repositories/onboarding/onboarding_repository_impl.dart
@@ -1,0 +1,21 @@
+import 'package:injectable/injectable.dart';
+import 'package:mystore/core/local_storage/shared_preferences/shared_preferences_data_source.dart';
+import 'package:mystore/core/repositories/onboarding/onboarding_repository.dart';
+
+@LazySingleton(as: OnboardingRepository)
+class OnboardingRepositoryImpl implements OnboardingRepository {
+  static const onboardingCompleted = 'onboarding_completed';
+
+  final SharedPreferencesDataSource _dataSource;
+  OnboardingRepositoryImpl(this._dataSource);
+
+  @override
+  Future<void> setOnboardingCompleted(bool value) async {
+    await _dataSource.saveBool(onboardingCompleted, value);
+  }
+
+  @override
+  Future<bool> isOnboardingCompleted() async {
+    return await _dataSource.getBool(onboardingCompleted);
+  }
+}


### PR DESCRIPTION
### Summary
Added onboarding repository to manage onboarding completion state

### What changed?
- Created `OnboardingRepository` abstract class with methods to manage onboarding state
- Implemented `OnboardingRepositoryImpl` with SharedPreferences storage
- Added methods to set and check onboarding completion status

### How to test?
1. Call `setOnboardingCompleted(true)` to mark onboarding as complete
2. Verify `isOnboardingCompleted()` returns true
3. Call `setOnboardingCompleted(false)` to reset onboarding
4. Verify `isOnboardingCompleted()` returns false

### Why make this change?
To provide a persistent storage solution for tracking whether a user has completed the app's onboarding process, ensuring users only see onboarding screens when necessary.