### PR TITLE
Authentication Repository

### DIFF
--- a/lib/core/injection/injection_container.config.dart
+++ b/lib/core/injection/injection_container.config.dart
@@ -22,10 +22,10 @@ import '../../features/authentication/data/data_sources/local_data_source.dart'
     as _i7;
 import '../../features/authentication/data/data_sources/remote_data_source.dart'
     as _i13;
-import '../../features/authentication/data/repositories/authentication_repository.dart'
-    as _i17;
-import '../../features/authentication/domain/repositories/authentication_repository_impl.dart'
+import '../../features/authentication/data/repositories/authentication_repository_impl.dart'
     as _i18;
+import '../../features/authentication/domain/repositories/authentication_repository.dart'
+    as _i17;
 import '../../features/authentication/domain/usecase/register_form_validation_use_case.dart'
     as _i12;
 import '../../features/authentication/domain/usecase/register_user_use_case.dart'

--- a/lib/features/authentication/data/repositories/authentication_repository_impl.dart
+++ b/lib/features/authentication/data/repositories/authentication_repository_impl.dart
@@ -1,0 +1,43 @@
+import 'package:injectable/injectable.dart';
+import 'package:mystore/core/error/exceptions.dart';
+import 'package:mystore/core/error/failures.dart';
+import 'package:mystore/features/authentication/data/data_sources/local_data_source.dart';
+import 'package:mystore/features/authentication/data/data_sources/remote_data_source.dart';
+import 'package:mystore/features/authentication/data/models/user_model.dart';
+import 'package:mystore/features/authentication/domain/entities/user_entity.dart';
+import 'package:mystore/features/authentication/domain/repositories/authentication_repository.dart';
+
+@Injectable(as: AuthenticationRepository)
+class AuthenticationRepositoryImpl implements AuthenticationRepository {
+  final RemoteDataSource remoteDataSource;
+  final LocalDataSource localDataSource;
+
+  AuthenticationRepositoryImpl({
+    required this.remoteDataSource,
+    required this.localDataSource,
+  });
+
+  @override
+  Future<(Failure?, UserEntity?)> signUpWithEmailAndPassword({
+    required String email,
+    required String password,
+    required UserEntity user,
+  }) async {
+    try {
+      final UserModel userModel =
+          await remoteDataSource.signUpWithEmailAndPassword(
+        email: email,
+        password: password,
+        user: UserModel.fromEntity(user),
+      );
+
+      await localDataSource.cacheUser(userModel.toIsarUserModel());
+
+      return (null, userModel);
+    } on ServerException catch (e) {
+      return (ServerFailure(e.message), null);
+    } on CacheException catch (e) {
+      return (CacheFailure(e.message), null);
+    }
+  }
+}

--- a/lib/features/authentication/domain/repositories/authentication_repository.dart
+++ b/lib/features/authentication/domain/repositories/authentication_repository.dart
@@ -1,0 +1,10 @@
+import 'package:mystore/core/error/failures.dart';
+import 'package:mystore/features/authentication/domain/entities/user_entity.dart';
+
+abstract class AuthenticationRepository {
+  Future<(Failure?, UserEntity?)> signUpWithEmailAndPassword({
+    required String email,
+    required String password,
+    required UserEntity user,
+  });
+}


### PR DESCRIPTION
### Summary
Implemented authentication repository with email/password signup functionality

### What changed?
- Created `AuthenticationRepository` interface with `signUpWithEmailAndPassword` method
- Implemented `AuthenticationRepositoryImpl` with email/password signup logic
- Added proper error handling for server and cache exceptions
- Fixed import paths in dependency injection configuration

### How to test?
1. Attempt to sign up a new user with email and password
2. Verify successful user creation and caching
3. Test error scenarios:
   - Invalid credentials
   - Server connection issues
   - Cache storage failures

### Why make this change?
To establish a clean architecture pattern for authentication, separating the interface from implementation while providing a robust way to handle user registration with proper error handling and local caching support.