### PR TITLE
Register User Use Case

### DIFF
--- a/lib/features/authentication/domain/usecase/register_user_use_case.dart
+++ b/lib/features/authentication/domain/usecase/register_user_use_case.dart
@@ -1,0 +1,30 @@
+import 'package:injectable/injectable.dart';
+import 'package:mystore/core/error/failures.dart';
+import 'package:mystore/core/usecases/usecase.dart';
+import 'package:mystore/features/authentication/domain/entities/user_entity.dart';
+import 'package:mystore/features/authentication/domain/repositories/authentication_repository.dart';
+
+@lazySingleton
+class RegisterUserUseCase implements UseCase<UserEntity, RegisterUserParams> {
+  final AuthenticationRepository repository;
+
+  RegisterUserUseCase(this.repository);
+
+  @override
+  Future<(Failure?, UserEntity?)> call(params) async {
+    return await repository.signUpWithEmailAndPassword(
+      email: params.email,
+      password: params.password,
+      user: params.user,
+    );
+  }
+}
+
+class RegisterUserParams {
+  final String email;
+  final String password;
+  final UserEntity user;
+
+  RegisterUserParams(
+      {required this.email, required this.password, required this.user});
+}


### PR DESCRIPTION
### Summary
Added a new use case for user registration functionality

### What changed?
Created `RegisterUserUseCase` class that implements the base `UseCase` interface to handle user registration. The class takes email, password, and user entity as parameters and interfaces with the authentication repository to perform the sign-up operation.

### How to test?
1. Create a new instance of `RegisterUserParams` with valid email, password, and user data
2. Initialize `RegisterUserUseCase` with a proper repository implementation
3. Call the use case with the params and verify that it returns the expected user entity
4. Test with invalid credentials to ensure proper failure handling

### Why make this change?
To implement a clean architecture pattern for user registration functionality, separating business logic from the data layer and providing a clear interface for the presentation layer to interact with the authentication system.