### PR TITLE
Fixing validation

### DIFF
--- a/lib/core/inputs/user_inputs.dart
+++ b/lib/core/inputs/user_inputs.dart
@@ -39,8 +39,6 @@ class FirstName extends FormzInput<String, ReportProblemFormError> {
 }
 
 class LastName extends FormzInput<String, ReportProblemFormError> {
-  static const int minLength = 2;
-
   const LastName.pure() : super.pure('');
   const LastName.dirty(super.value) : super.dirty();
 
@@ -67,7 +65,7 @@ class Username extends FormzInput<String, ReportProblemFormError> {
       return ReportProblemFormError.empty;
     } else if (value.length < minLength) {
       return ReportProblemFormError.username;
-    } else if (!RegExp(r'^[A-Za-z0-9_.]+$').hasMatch(value)) {
+    } else if (!RegExp(r'^[A-Za-z]+$').hasMatch(value)) {
       return ReportProblemFormError.invalid;
     }
     return null;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -680,6 +680,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  lottie:
+    dependency: "direct main"
+    description:
+      name: lottie
+      sha256: "7afc60865a2429d994144f7d66ced2ae4305fe35d82890b8766e3359872d872c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
   matcher:
     dependency: transitive
     description:
@@ -1053,6 +1061,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  top_snackbar_flutter:
+    dependency: "direct main"
+    description:
+      name: top_snackbar_flutter
+      sha256: "22d14664a13db6ac714934c3382bd8d4daa57fb888a672f922df71981c5a5cb2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   intl: ^0.19.0
   logger: ^2.3.0
   get_it: ^7.7.0
+  lottie: ^3.1.3
   freezed: ^2.5.2
   equatable: ^2.0.5
   go_router: ^14.2.0
@@ -30,6 +31,7 @@ dependencies:
   flutter_stripe: ^11.0.0
   freezed_annotation: ^2.4.4
   shared_preferences: ^2.3.2
+  top_snackbar_flutter: ^3.1.0
   smooth_page_indicator: ^1.1.0
   flutter_native_splash: ^2.4.1
   internet_connection_checker: ^1.0.0+1


### PR DESCRIPTION
### Summary
Updated username validation to only allow alphabetic characters and removed unused minimum length constant for last name.

### What changed?
- Modified username regex pattern from `^[A-Za-z0-9_.]+$` to `^[A-Za-z]+$`
- Removed unused `minLength` constant from `LastName` class

### How to test?
1. Try creating a username with numbers or special characters - should be rejected
2. Try creating a username with only letters - should be accepted
3. Verify last name validation still works as expected

### Why make this change?
To enforce stricter username requirements by only allowing alphabetic characters, making usernames more consistent and readable. The `minLength` constant was removed from the `LastName` class as it wasn't being used in the validation logic.