### PR TITLE
Add Loading and Snackbar Widgets

### DIFF
--- a/lib/core/common_widgets/widgets/loaders/animation_loader.dart
+++ b/lib/core/common_widgets/widgets/loaders/animation_loader.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:lottie/lottie.dart';
+import 'package:mystore/core/constants/colors.dart';
+import 'package:mystore/core/constants/sizes.dart';
+import 'package:mystore/core/utils/decoder/decoder.dart';
+
+class MyAnimationLoader extends StatelessWidget {
+  final String? text;
+  final String animation;
+  final bool showAction;
+  final String? actionText;
+  final VoidCallback? onActionTap;
+
+  const MyAnimationLoader({
+    super.key,
+    required this.animation,
+    this.text,
+    this.showAction = false,
+    this.actionText,
+    this.onActionTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        children: [
+          Lottie.asset(
+            animation,
+            width: MediaQuery.of(context).size.width * 0.8,
+            decoder: (bytes) => MyLottieDecoder.customDecoder(bytes),
+          ),
+          const SizedBox(height: MySizes.defaultSpace),
+          text != null
+              ? Text(
+                  text!,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                  textAlign: TextAlign.center,
+                )
+              : const SizedBox(),
+          const SizedBox(height: MySizes.defaultSpace),
+          showAction
+              ? SizedBox(
+                  width: 250,
+                  child: OutlinedButton(
+                    onPressed: onActionTap,
+                    child: Text(
+                      actionText!,
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodyMedium!
+                          .apply(color: MyColors.light),
+                    ),
+                  ),
+                )
+              : const SizedBox(),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/core/common_widgets/widgets/loaders/full_screen_loader.dart
+++ b/lib/core/common_widgets/widgets/loaders/full_screen_loader.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:mystore/core/common_widgets/widgets/loaders/animation_loader.dart';
+import 'package:mystore/core/constants/colors.dart';
+import 'package:mystore/core/utils/helpers/helper_functions.dart';
+
+class MyFullScreenLoader {
+  static void showLoadingDialog(
+      {required BuildContext context,
+      String? message,
+      required String animation}) {
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return PopScope(
+          canPop: false,
+          child: Container(
+            color: MyHelperFunctions.isDarkMode(context)
+                ? MyColors.dark
+                : MyColors.white,
+            width: double.infinity,
+            height: double.infinity,
+            child: Column(
+              children: [
+                const SizedBox(height: 250),
+                MyAnimationLoader(text: message, animation: animation)
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  static stopLoadingDialog(BuildContext context) {
+    Navigator.of(context).pop();
+  }
+}

--- a/lib/core/common_widgets/widgets/snackbar/snackbar.dart
+++ b/lib/core/common_widgets/widgets/snackbar/snackbar.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:top_snackbar_flutter/custom_snack_bar.dart';
+
+class MySnackBar {
+  static errorSnackBar({String message = ''}) {
+    return SnackBar(
+      elevation: 0,
+      behavior: SnackBarBehavior.floating,
+      backgroundColor: Colors.transparent,
+      dismissDirection: DismissDirection.horizontal,
+      content: CustomSnackBar.error(
+        message: message,
+      ),
+    );
+  }
+
+  static successSnackBar({String message = ''}) {
+    return SnackBar(
+      elevation: 0,
+      behavior: SnackBarBehavior.floating,
+      backgroundColor: Colors.transparent,
+      dismissDirection: DismissDirection.horizontal,
+      content: CustomSnackBar.success(
+        message: message,
+      ),
+    );
+  }
+
+  static warningSnackBar({String message = ''}) {
+    return SnackBar(
+      elevation: 0,
+      behavior: SnackBarBehavior.floating,
+      backgroundColor: Colors.transparent,
+      dismissDirection: DismissDirection.horizontal,
+      content: CustomSnackBar.info(
+        backgroundColor: Colors.orange,
+        message: message,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### Summary
Added new loader and snackbar widgets for consistent UI feedback across the app.

### What changed?
- Created `MyAnimationLoader` widget for displaying Lottie animations with optional text and action buttons
- Added `MyFullScreenLoader` for showing full-screen loading states with animations
- Implemented `MySnackBar` with three variants: error, success, and warning messages

### How to test?
1. Test `MyAnimationLoader`:
   - Verify animation displays correctly with different screen sizes
   - Check text alignment and visibility
   - Confirm action button functionality when enabled

2. Test `MyFullScreenLoader`:
   - Verify loader appears and blocks user interaction
   - Confirm proper dark/light mode background colors
   - Test that loader dismisses correctly

3. Test `MySnackBar`:
   - Trigger each snackbar variant (error, success, warning)
   - Verify messages display correctly
   - Check dismiss functionality works by swiping

### Why make this change?
To provide a consistent and professional user feedback system throughout the app, making it easier to communicate loading states and status messages to users. These reusable components will reduce code duplication and maintain UI consistency.