### PR TITLE
Check user status

### DIFF
--- a/lib/features/authentication/domain/usecase/check_user_status_use_case.dart
+++ b/lib/features/authentication/domain/usecase/check_user_status_use_case.dart
@@ -1,0 +1,28 @@
+import 'package:injectable/injectable.dart';
+import 'package:mystore/core/error/failures.dart';
+import 'package:mystore/core/usecases/usecase.dart';
+import 'package:mystore/features/authentication/domain/repositories/authentication_repository.dart';
+
+enum UserStatus { notAuthenticated, emailNotVerified, emailVerified }
+
+@injectable
+class CheckUserStatusUseCase implements UseCase<UserStatus, NoParams> {
+  final AuthenticationRepository repository;
+
+  CheckUserStatusUseCase({required this.repository});
+
+  @override
+  Future<(Failure?, UserStatus?)> call(NoParams params) async {
+    final user = await repository.getCurrentUser();
+
+    if (user.$1 != null) {
+      return (user.$1, null);
+    } else if (user.$2 == null) {
+      return (null, UserStatus.notAuthenticated);
+    } else if (user.$2!.emailVerified) {
+      return (null, UserStatus.emailVerified);
+    } else {
+      return (null, UserStatus.emailNotVerified);
+    }
+  }
+}


### PR DESCRIPTION
### Summary
Added a new use case to check user authentication and email verification status

### What changed?
Created `CheckUserStatusUseCase` that returns one of three possible states:
- `notAuthenticated`: User is not logged in
- `emailNotVerified`: User is logged in but email isn't verified
- `emailVerified`: User is logged in with verified email

### How to test?
1. Try accessing the app without logging in - should return `notAuthenticated`
2. Log in with an unverified email - should return `emailNotVerified`
3. Log in with a verified email - should return `emailVerified`
4. Test error handling by simulating repository failures

### Why make this change?
To provide a centralized way to determine user authentication state, allowing the app to make appropriate UI/navigation decisions based on the user's current status. This helps enforce email verification requirements and proper authentication flows.