### PR TITLE
Logout user

### DIFF
--- a/lib/features/authentication/domain/usecase/logout_user_use_case.dart
+++ b/lib/features/authentication/domain/usecase/logout_user_use_case.dart
@@ -1,0 +1,16 @@
+import 'package:injectable/injectable.dart';
+import 'package:mystore/core/error/failures.dart';
+import 'package:mystore/core/usecases/usecase.dart';
+import 'package:mystore/features/authentication/domain/repositories/authentication_repository.dart';
+
+@lazySingleton
+class LogoutUserUseCase implements UseCase<void, NoParams> {
+  final AuthenticationRepository repository;
+
+  LogoutUserUseCase({required this.repository});
+
+  @override
+  Future<(Failure?, void)> call(NoParams params) async {
+    return await repository.logOut();
+  }
+}


### PR DESCRIPTION
### Summary
Added a new use case for handling user logout functionality

### What changed?
Created `LogoutUserUseCase` class that implements the base `UseCase` interface to manage user logout operations through the authentication repository

### How to test?
1. Inject `LogoutUserUseCase` into a component
2. Call the use case with `NoParams`
3. Verify that the repository's `logOut` method is called
4. Confirm the returned tuple contains either a failure or void result

### Why make this change?
To encapsulate the logout business logic in a dedicated use case, following clean architecture principles and making the logout functionality more maintainable and testable