### PR TITLE
Send email verification

### DIFF
--- a/lib/features/authentication/domain/usecase/send_email_verification_use_case.dart
+++ b/lib/features/authentication/domain/usecase/send_email_verification_use_case.dart
@@ -1,0 +1,16 @@
+import 'package:injectable/injectable.dart';
+import 'package:mystore/core/error/failures.dart';
+import 'package:mystore/core/usecases/usecase.dart';
+import 'package:mystore/features/authentication/domain/repositories/authentication_repository.dart';
+
+@lazySingleton
+class SendEmailVerificationUseCase implements UseCase<void, NoParams> {
+  final AuthenticationRepository repository;
+
+  SendEmailVerificationUseCase(this.repository);
+
+  @override
+  Future<(Failure?, void)> call(_) async {
+    return await repository.sendEmailVerification();
+  }
+}


### PR DESCRIPTION
### Summary
Added a new use case for sending email verification

### What changed?
Created `SendEmailVerificationUseCase` that interfaces with the authentication repository to handle email verification sending functionality

### How to test?
1. Inject `SendEmailVerificationUseCase` into a component
2. Call the use case with `NoParams`
3. Verify that the email verification is sent through the repository
4. Check error handling by testing failure scenarios

### Why make this change?
To encapsulate email verification logic in a dedicated use case, following clean architecture principles and making the feature more maintainable and testable