### PR TITLE
managing the states

### DIFF
--- a/lib/features/authentication/presentation/screens/signup/signup.dart
+++ b/lib/features/authentication/presentation/screens/signup/signup.dart
@@ -32,8 +32,8 @@ class SignupScreen extends StatelessWidget {
               ..hideCurrentSnackBar()
               ..showSnackBar(MySnackBar.errorSnackBar(message: message));
           },
-          success: (message) {
-            context.goNamed(MyRoutes.verifyEmail.name);
+          success: (message, email) {
+            context.goNamed(MyRoutes.verifyEmail.name, extra: email);
 
             ScaffoldMessenger.of(context)
               ..hideCurrentSnackBar()

--- a/lib/features/authentication/presentation/screens/signup/widgets/signup_form.dart
+++ b/lib/features/authentication/presentation/screens/signup/widgets/signup_form.dart
@@ -208,8 +208,6 @@ class _SignupFormState extends State<SignupForm> {
                                 privacyAccepted: isPrivacyAccepted,
                               ),
                             );
-
-                        // context.goNamed(MyRoutes.verifyEmail.name);
                       },
                       child: const Text(MyTexts.createAccount),
                     ),


### PR DESCRIPTION
### Summary
Added email parameter to verify email navigation after signup

### What changed?
- Modified the success callback in signup screen to pass email as an extra parameter when navigating to verify email screen
- Removed commented out navigation code in signup form

### How to test?
1. Complete the signup form with valid credentials
2. Submit the form
3. Verify that you are redirected to the email verification screen
4. Confirm that the email entered during signup is properly passed to the verification screen

### Why make this change?
To ensure the email verification screen has access to the user's email address, enabling proper verification flow and improving user experience by maintaining context between screens