### PR TITLE
format time extension

### DIFF
--- a/lib/core/utils/extensions/extensions.dart
+++ b/lib/core/utils/extensions/extensions.dart
@@ -10,3 +10,11 @@ extension StringExtension on String {
         .join(' ');
   }
 }
+
+extension IntExtendion on int {
+  String get formatTime {
+    final minutes = (this ~/ 60).toString().padLeft(1, '0'); // Minutes
+    final seconds = (this % 60).toString().padLeft(2, '0'); // Seconds
+    return '$minutes:$seconds';
+  }
+}


### PR DESCRIPTION
### Summary
Added a new time formatting extension method for integers

### What changed?
Added `formatTime` extension method on `int` that converts seconds into a "minutes:seconds" format (e.g., "2:05")

### How to test?
1. Create an integer representing seconds (e.g., 125)
2. Call the formatTime getter on the integer (e.g., `125.formatTime`)
3. Verify the output matches the expected format (e.g., "2:05")

### Why make this change?
To provide a convenient way to format time durations from seconds into a human-readable format, commonly used for displaying media playback times or countdown timers