### PR TITLE
User Auth Credentials Entity

### DIFF
--- a/lib/features/authentication/domain/entities/user_entity.dart
+++ b/lib/features/authentication/domain/entities/user_entity.dart
@@ -1,8 +1,6 @@
-class UserEntity {
+class UserEntity extends UserAuthCredentials {
   final String firstName;
   final String lastName;
-  final String email;
-  final String password;
   final String username;
   final String phoneNumber;
   final String? photo;
@@ -10,10 +8,20 @@ class UserEntity {
   const UserEntity({
     required this.firstName,
     required this.lastName,
-    required this.email,
-    required this.password,
     required this.username,
     required this.phoneNumber,
+    required super.email,
+    required super.password,
     this.photo,
+  });
+}
+
+class UserAuthCredentials {
+  final String email;
+  final String password;
+
+  const UserAuthCredentials({
+    required this.email,
+    required this.password,
   });
 }


### PR DESCRIPTION
User Auth Credentials Entity

- Created new `UserAuthCredentials` base class with email and password fields
- Extended `UserEntity` from `UserAuthCredentials` to inherit authentication properties
- Added `signInWithEmailAndPassword` method to `RemoteDataSource` for Firebase authentication
- Implemented user document retrieval from Firestore after successful authentication