### PR TITLE
Login methods

### DIFF
--- a/lib/features/authentication/data/repositories/authentication_repository_impl.dart
+++ b/lib/features/authentication/data/repositories/authentication_repository_impl.dart
@@ -1,8 +1,8 @@
-
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:injectable/injectable.dart';
 import 'package:mystore/core/error/exceptions.dart';
 import 'package:mystore/core/error/failures.dart';
+import 'package:mystore/core/local_storage/shared_preferences/shared_preferences_data_source.dart';
 import 'package:mystore/features/authentication/data/data_sources/local_data_source.dart';
 import 'package:mystore/features/authentication/data/data_sources/remote_data_source.dart';
 import 'package:mystore/features/authentication/data/models/user_model.dart';
@@ -11,12 +11,17 @@ import 'package:mystore/features/authentication/domain/repositories/authenticati
 
 @Injectable(as: AuthenticationRepository)
 class AuthenticationRepositoryImpl implements AuthenticationRepository {
+  final SharedPreferencesDataSource sharedPreferencesDataSource;
   final RemoteDataSource remoteDataSource;
   final LocalDataSource localDataSource;
+
+  static const rememberEmail = 'remember_email';
+  static const rememberPassword = 'remember_password';
 
   AuthenticationRepositoryImpl({
     required this.remoteDataSource,
     required this.localDataSource,
+    required this.sharedPreferencesDataSource,
   });
 
   @override
@@ -80,6 +85,65 @@ class AuthenticationRepositoryImpl implements AuthenticationRepository {
       return (null, user);
     } on ServerException catch (e) {
       return (ServerFailure(e.message), null);
+    }
+  }
+
+  @override
+  Future<(Failure?, UserEntity?)> signInWithEmailAndPassword({
+    required String email,
+    required String password,
+    required bool rememberMe,
+  }) async {
+    try {
+      final UserModel userModel =
+          await remoteDataSource.signInWithEmailAndPassword(
+        email: email,
+        password: password,
+      );
+
+      await localDataSource.cacheUser(userModel.toIsarUserModel());
+
+      return (null, userModel);
+    } on ServerException catch (e) {
+      return (ServerFailure(e.message), null);
+    } on CacheException catch (e) {
+      return (CacheFailure(e.message), null);
+    } catch (e) {
+      return (ServerFailure(e.toString()), null);
+    }
+  }
+
+  @override
+  Future<UserAuthCredentials?> getCredentials() async {
+    final email = await sharedPreferencesDataSource.getString(rememberEmail);
+    final password =
+        await sharedPreferencesDataSource.getString(rememberPassword);
+
+    if (email.isNotEmpty || password.isNotEmpty) {
+
+        
+    return UserAuthCredentials(email: email, password: password);;
+
+    }else{
+      return null;
+    }
+  }
+
+  @override
+  Future<void> clearCredentials() async {
+    await sharedPreferencesDataSource.remove(rememberEmail);
+    await sharedPreferencesDataSource.remove(rememberPassword);
+  }
+
+  @override
+  Future<(Failure?, void)> saveCredentials(
+      {required String email, required String password}) async {
+    try {
+      await sharedPreferencesDataSource.saveString(rememberEmail, email);
+      await sharedPreferencesDataSource.saveString(rememberPassword, password);
+      return (null, null);
+    } catch (e) {
+      return (CacheFailure(e.toString()), null);
     }
   }
 }

--- a/lib/features/authentication/domain/repositories/authentication_repository.dart
+++ b/lib/features/authentication/domain/repositories/authentication_repository.dart
@@ -16,4 +16,19 @@ abstract class AuthenticationRepository {
   Future<(Failure?, void)> logOut();
 
   Future<(Failure?, User?)> getCurrentUser();
+
+  Future<(Failure?, UserEntity?)> signInWithEmailAndPassword({
+    required String email,
+    required String password,
+    required bool rememberMe,
+  });
+
+  Future<UserAuthCredentials?> getCredentials();
+
+  Future<(Failure?, void)> saveCredentials({
+    required String email,
+    required String password,
+  });
+
+  Future<void> clearCredentials();
 }


### PR DESCRIPTION
### Summary
Added functionality to remember user credentials for authentication

### What changed?
- Added methods to save and retrieve user email/password credentials using SharedPreferences
- Implemented `signInWithEmailAndPassword` with remember me functionality
- Added new repository methods for credential management: `getCredentials`, `saveCredentials`, and `clearCredentials`
- Introduced `UserAuthCredentials` handling for stored login information

### How to test?
1. Log in with "Remember Me" enabled and verify credentials are saved
2. Close and reopen the app to confirm saved credentials are retrieved
3. Test clearing credentials using the logout flow
4. Verify login works with both saved and manually entered credentials

### Why make this change?
To improve user experience by allowing users to save their login credentials, eliminating the need to re-enter email and password on subsequent app launches. This is a commonly requested feature that reduces friction in the authentication process.