### PR TITLE
Register Form Use Case

### DIFF
--- a/lib/features/authentication/domain/usecase/register_form_validation_use_case.dart
+++ b/lib/features/authentication/domain/usecase/register_form_validation_use_case.dart
@@ -5,41 +5,40 @@ import 'package:mystore/core/inputs/user_inputs.dart';
 import 'package:mystore/core/usecases/usecase.dart';
 
 @lazySingleton
-class RegisterFormValidationUseCase
-    implements UseCase<bool, RegisterFormValidationParams> {
+class FormValidationUseCase implements UseCase<bool, FormValidationParams> {
   @override
   Future<(Failure?, bool?)> call(params) async {
-    final formStatus = Formz.validate([
-      params.firstName,
-      params.lastName,
-      params.username,
-      params.email,
-      params.phoneNumber,
-      params.password,
+    final isMandatoryValid = Formz.validate([params.email, params.password]);
+
+    final isOptionalValid = Formz.validate([
+      if (params.firstName != null) params.firstName!,
+      if (params.lastName != null) params.lastName!,
+      if (params.username != null) params.username!,
+      if (params.phoneNumber != null) params.phoneNumber!,
     ]);
 
-    if (formStatus) {
-      return (null, true);
+    if (isMandatoryValid && isOptionalValid) {
+       return (null, true);
     } else {
       return (InvalidFormFailure('Invalid form'), false);
     }
   }
 }
 
-class RegisterFormValidationParams {
+class FormValidationParams {
   final Email email;
   final Password password;
-  final FirstName firstName;
-  final LastName lastName;
-  final Username username;
-  final PhoneNumber phoneNumber;
+  final FirstName? firstName;
+  final LastName? lastName;
+  final Username? username;
+  final PhoneNumber? phoneNumber;
 
-  RegisterFormValidationParams({
+  FormValidationParams({
     required this.email,
     required this.password,
-    required this.firstName,
-    required this.lastName,
-    required this.username,
-    required this.phoneNumber,
+    this.firstName,
+    this.lastName,
+    this.username,
+    this.phoneNumber,
   });
 }


### PR DESCRIPTION
### Summary
Refactored form validation to support optional user registration fields

### What changed?
- Renamed `RegisterFormValidationUseCase` to `FormValidationUseCase`
- Split form validation into mandatory (email, password) and optional fields
- Made firstName, lastName, username, and phoneNumber optional parameters
- Updated validation logic to only validate optional fields when they are provided

### How to test?
1. Test form submission with only email and password
2. Test form submission with various combinations of optional fields
3. Verify form validation succeeds with valid mandatory fields
4. Verify optional fields are properly validated when provided

### Why make this change?
To provide more flexibility in the registration process by allowing users to submit forms with only required fields, while maintaining the ability to validate optional fields when they are provided. This change supports different registration flows and user preferences.