### PR TITLE
Sign In With Email and Password Use Case

### DIFF
--- a/lib/features/authentication/domain/usecase/sign_in_with_email_password.dart
+++ b/lib/features/authentication/domain/usecase/sign_in_with_email_password.dart
@@ -1,0 +1,34 @@
+import 'package:injectable/injectable.dart';
+import 'package:mystore/core/error/failures.dart';
+import 'package:mystore/core/usecases/usecase.dart';
+import 'package:mystore/features/authentication/domain/entities/user_entity.dart';
+import 'package:mystore/features/authentication/domain/repositories/authentication_repository.dart';
+
+@injectable
+class SignInWithEmailAndPasswordUseCase
+    implements UseCase<UserEntity?, SignInWithEmailAndPasswordParams> {
+  final AuthenticationRepository repository;
+
+  SignInWithEmailAndPasswordUseCase(this.repository);
+
+  @override
+  Future<(Failure?, UserEntity?)> call(params) async {
+    return await repository.signInWithEmailAndPassword(
+      email: params.email,
+      password: params.password,
+      rememberMe: params.rememberMe,
+    );
+  }
+}
+
+class SignInWithEmailAndPasswordParams {
+  final String email;
+  final String password;
+  final bool rememberMe;
+
+  SignInWithEmailAndPasswordParams({
+    required this.email,
+    required this.password,
+    required this.rememberMe,
+  });
+}


### PR DESCRIPTION
### Summary
Added a new use case for email and password authentication sign-in functionality.

### What changed?
Created `SignInWithEmailAndPasswordUseCase` class that handles the sign-in process through email and password credentials. The use case implements the `UseCase` interface and works with the authentication repository to process sign-in requests.

### How to test?
1. Create an instance of `SignInWithEmailAndPasswordUseCase`
2. Call the use case with valid email, password, and rememberMe parameters
3. Verify that it returns a tuple containing either a Failure or UserEntity
4. Test with both valid and invalid credentials to ensure proper error handling

### Why make this change?
To implement a clean architecture pattern for the authentication flow, separating business logic from the implementation details. This use case provides a standardized way to handle email/password authentication while maintaining dependency injection principles.