### PR TITLE
Remember Me Use Case

### DIFF
--- a/lib/features/authentication/domain/usecase/remember_me_use_case.dart
+++ b/lib/features/authentication/domain/usecase/remember_me_use_case.dart
@@ -1,0 +1,33 @@
+import 'package:injectable/injectable.dart';
+import 'package:mystore/core/error/failures.dart';
+import 'package:mystore/core/usecases/usecase.dart';
+import 'package:mystore/features/authentication/domain/entities/user_entity.dart';
+import 'package:mystore/features/authentication/domain/repositories/authentication_repository.dart';
+
+@injectable
+class RememberMeUseCase implements UseCase<void, RmemeberMeParams> {
+  final AuthenticationRepository repository;
+
+  RememberMeUseCase({required this.repository});
+
+  @override
+  Future<(Failure?, void)> call(RmemeberMeParams params) async {
+    return await repository.saveCredentials(
+        email: params.email, password: params.password);
+  }
+
+  Future<UserAuthCredentials?> getSavedCredentials() async {
+    return await repository.getCredentials();
+  }
+
+  Future<void> clearSavedCredentials() async {
+    await repository.clearCredentials();
+  }
+}
+
+class RmemeberMeParams {
+  final String email;
+  final String password;
+
+  RmemeberMeParams({required this.email, required this.password});
+}


### PR DESCRIPTION
### Summary
Added new RememberMeUseCase to handle user credential persistence functionality

### What changed?
- Created a new `RememberMeUseCase` class that implements the `UseCase` interface
- Added methods to save, retrieve, and clear user credentials
- Implemented `RmemeberMeParams` class to handle email and password parameters

### How to test?
1. Attempt to save user credentials using the `call` method with email and password
2. Verify saved credentials can be retrieved using `getSavedCredentials`
3. Test clearing credentials using `clearSavedCredentials`
4. Verify credentials are properly cleared after using clear method

### Why make this change?
To implement "Remember Me" functionality, allowing users to persist their login credentials between sessions, improving the user experience by eliminating the need to re-enter credentials on subsequent app launches.