### PR TITLE
Sign in bloc

### DIFF
--- a/lib/features/authentication/presentation/bloc/sign_in_form/sign_in_form_bloc.dart
+++ b/lib/features/authentication/presentation/bloc/sign_in_form/sign_in_form_bloc.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:injectable/injectable.dart';
+import 'package:mystore/core/inputs/user_inputs.dart';
+import 'package:mystore/features/authentication/domain/usecase/register_form_validation_use_case.dart';
+import 'package:mystore/features/authentication/domain/usecase/remember_me_use_case.dart';
+
+part 'sign_in_form_event.dart';
+part 'sign_in_form_state.dart';
+part 'sign_in_form_bloc.freezed.dart';
+
+@injectable
+class SignInFormBloc extends Bloc<SignInFormEvent, SignInFormState> {
+  final FormValidationUseCase formValidationUseCase;
+  final RememberMeUseCase rememberMeUseCase;
+
+  SignInFormBloc(this.formValidationUseCase, this.rememberMeUseCase)
+      : super(const SignInFormState()) {
+    on<SignInFormEvent>((event, emit) async {
+      final credentials = await rememberMeUseCase.getSavedCredentials();
+
+      if (credentials != null) {
+        emit(
+          state.copyWith(
+            email: Email.dirty(credentials.email),
+            password: Password.dirty(credentials.password),
+          ),
+        );
+      }
+
+      await event.when(
+        started: () {},
+        formSubmitted: (email, password) async {
+          /// Validates the sign-in form using the provided parameters and emits an error state if validation fails.
+          ///
+          /// This method calls the `signInFormValidationUseCase` with the given parameters:
+          /// - `email`: The email address to validate.
+          /// - `password`: The password to validate.
+          ///
+          /// If the form validation fails (`formStatus.$2` is `false`), it emits an `AuthenticationState.error`
+          /// with the validation error message (`formStatus.$1!.message`).
+          ///
+          /// Returns immediately after emitting the error state if validation fails.
+          final mail = Email.dirty(email);
+          final pass = Password.dirty(password);
+
+          final formStatus = await formValidationUseCase.call(
+            FormValidationParams(
+              email: mail,
+              password: pass,
+            ),
+          );
+
+          emit(
+            state.copyWith(
+              email: mail,
+              password: pass,
+              isFormValid: formStatus.$2,
+            ),
+          );
+        },
+      );
+    });
+  }
+}

--- a/lib/features/authentication/presentation/bloc/sign_in_form/sign_in_form_bloc.freezed.dart
+++ b/lib/features/authentication/presentation/bloc/sign_in_form/sign_in_form_bloc.freezed.dart
@@ -1,0 +1,482 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'sign_in_form_bloc.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$SignInFormEvent {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String email, String password) formSubmitted,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String email, String password)? formSubmitted,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String email, String password)? formSubmitted,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_FormSubmitted value) formSubmitted,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_FormSubmitted value)? formSubmitted,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_FormSubmitted value)? formSubmitted,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SignInFormEventCopyWith<$Res> {
+  factory $SignInFormEventCopyWith(
+          SignInFormEvent value, $Res Function(SignInFormEvent) then) =
+      _$SignInFormEventCopyWithImpl<$Res, SignInFormEvent>;
+}
+
+/// @nodoc
+class _$SignInFormEventCopyWithImpl<$Res, $Val extends SignInFormEvent>
+    implements $SignInFormEventCopyWith<$Res> {
+  _$SignInFormEventCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$StartedImplCopyWith<$Res> {
+  factory _$$StartedImplCopyWith(
+          _$StartedImpl value, $Res Function(_$StartedImpl) then) =
+      __$$StartedImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$StartedImplCopyWithImpl<$Res>
+    extends _$SignInFormEventCopyWithImpl<$Res, _$StartedImpl>
+    implements _$$StartedImplCopyWith<$Res> {
+  __$$StartedImplCopyWithImpl(
+      _$StartedImpl _value, $Res Function(_$StartedImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$StartedImpl implements _Started {
+  const _$StartedImpl();
+
+  @override
+  String toString() {
+    return 'SignInFormEvent.started()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$StartedImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String email, String password) formSubmitted,
+  }) {
+    return started();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String email, String password)? formSubmitted,
+  }) {
+    return started?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String email, String password)? formSubmitted,
+    required TResult orElse(),
+  }) {
+    if (started != null) {
+      return started();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_FormSubmitted value) formSubmitted,
+  }) {
+    return started(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_FormSubmitted value)? formSubmitted,
+  }) {
+    return started?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_FormSubmitted value)? formSubmitted,
+    required TResult orElse(),
+  }) {
+    if (started != null) {
+      return started(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Started implements SignInFormEvent {
+  const factory _Started() = _$StartedImpl;
+}
+
+/// @nodoc
+abstract class _$$FormSubmittedImplCopyWith<$Res> {
+  factory _$$FormSubmittedImplCopyWith(
+          _$FormSubmittedImpl value, $Res Function(_$FormSubmittedImpl) then) =
+      __$$FormSubmittedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String email, String password});
+}
+
+/// @nodoc
+class __$$FormSubmittedImplCopyWithImpl<$Res>
+    extends _$SignInFormEventCopyWithImpl<$Res, _$FormSubmittedImpl>
+    implements _$$FormSubmittedImplCopyWith<$Res> {
+  __$$FormSubmittedImplCopyWithImpl(
+      _$FormSubmittedImpl _value, $Res Function(_$FormSubmittedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? email = null,
+    Object? password = null,
+  }) {
+    return _then(_$FormSubmittedImpl(
+      email: null == email
+          ? _value.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+      password: null == password
+          ? _value.password
+          : password // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$FormSubmittedImpl implements _FormSubmitted {
+  const _$FormSubmittedImpl({required this.email, required this.password});
+
+  @override
+  final String email;
+  @override
+  final String password;
+
+  @override
+  String toString() {
+    return 'SignInFormEvent.formSubmitted(email: $email, password: $password)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$FormSubmittedImpl &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.password, password) ||
+                other.password == password));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, email, password);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$FormSubmittedImplCopyWith<_$FormSubmittedImpl> get copyWith =>
+      __$$FormSubmittedImplCopyWithImpl<_$FormSubmittedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String email, String password) formSubmitted,
+  }) {
+    return formSubmitted(email, password);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String email, String password)? formSubmitted,
+  }) {
+    return formSubmitted?.call(email, password);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String email, String password)? formSubmitted,
+    required TResult orElse(),
+  }) {
+    if (formSubmitted != null) {
+      return formSubmitted(email, password);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_FormSubmitted value) formSubmitted,
+  }) {
+    return formSubmitted(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_FormSubmitted value)? formSubmitted,
+  }) {
+    return formSubmitted?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_FormSubmitted value)? formSubmitted,
+    required TResult orElse(),
+  }) {
+    if (formSubmitted != null) {
+      return formSubmitted(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _FormSubmitted implements SignInFormEvent {
+  const factory _FormSubmitted(
+      {required final String email,
+      required final String password}) = _$FormSubmittedImpl;
+
+  String get email;
+  String get password;
+  @JsonKey(ignore: true)
+  _$$FormSubmittedImplCopyWith<_$FormSubmittedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$SignInFormState {
+  Email get email => throw _privateConstructorUsedError;
+  Password get password => throw _privateConstructorUsedError;
+  bool? get isFormValid => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $SignInFormStateCopyWith<SignInFormState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SignInFormStateCopyWith<$Res> {
+  factory $SignInFormStateCopyWith(
+          SignInFormState value, $Res Function(SignInFormState) then) =
+      _$SignInFormStateCopyWithImpl<$Res, SignInFormState>;
+  @useResult
+  $Res call({Email email, Password password, bool? isFormValid});
+}
+
+/// @nodoc
+class _$SignInFormStateCopyWithImpl<$Res, $Val extends SignInFormState>
+    implements $SignInFormStateCopyWith<$Res> {
+  _$SignInFormStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? email = null,
+    Object? password = null,
+    Object? isFormValid = freezed,
+  }) {
+    return _then(_value.copyWith(
+      email: null == email
+          ? _value.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as Email,
+      password: null == password
+          ? _value.password
+          : password // ignore: cast_nullable_to_non_nullable
+              as Password,
+      isFormValid: freezed == isFormValid
+          ? _value.isFormValid
+          : isFormValid // ignore: cast_nullable_to_non_nullable
+              as bool?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$SignInFormStateImplCopyWith<$Res>
+    implements $SignInFormStateCopyWith<$Res> {
+  factory _$$SignInFormStateImplCopyWith(_$SignInFormStateImpl value,
+          $Res Function(_$SignInFormStateImpl) then) =
+      __$$SignInFormStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({Email email, Password password, bool? isFormValid});
+}
+
+/// @nodoc
+class __$$SignInFormStateImplCopyWithImpl<$Res>
+    extends _$SignInFormStateCopyWithImpl<$Res, _$SignInFormStateImpl>
+    implements _$$SignInFormStateImplCopyWith<$Res> {
+  __$$SignInFormStateImplCopyWithImpl(
+      _$SignInFormStateImpl _value, $Res Function(_$SignInFormStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? email = null,
+    Object? password = null,
+    Object? isFormValid = freezed,
+  }) {
+    return _then(_$SignInFormStateImpl(
+      email: null == email
+          ? _value.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as Email,
+      password: null == password
+          ? _value.password
+          : password // ignore: cast_nullable_to_non_nullable
+              as Password,
+      isFormValid: freezed == isFormValid
+          ? _value.isFormValid
+          : isFormValid // ignore: cast_nullable_to_non_nullable
+              as bool?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SignInFormStateImpl implements _SignInFormState {
+  const _$SignInFormStateImpl(
+      {this.email = const Email.pure(),
+      this.password = const Password.pure(),
+      this.isFormValid});
+
+  @override
+  @JsonKey()
+  final Email email;
+  @override
+  @JsonKey()
+  final Password password;
+  @override
+  final bool? isFormValid;
+
+  @override
+  String toString() {
+    return 'SignInFormState(email: $email, password: $password, isFormValid: $isFormValid)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SignInFormStateImpl &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.password, password) ||
+                other.password == password) &&
+            (identical(other.isFormValid, isFormValid) ||
+                other.isFormValid == isFormValid));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, email, password, isFormValid);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SignInFormStateImplCopyWith<_$SignInFormStateImpl> get copyWith =>
+      __$$SignInFormStateImplCopyWithImpl<_$SignInFormStateImpl>(
+          this, _$identity);
+}
+
+abstract class _SignInFormState implements SignInFormState {
+  const factory _SignInFormState(
+      {final Email email,
+      final Password password,
+      final bool? isFormValid}) = _$SignInFormStateImpl;
+
+  @override
+  Email get email;
+  @override
+  Password get password;
+  @override
+  bool? get isFormValid;
+  @override
+  @JsonKey(ignore: true)
+  _$$SignInFormStateImplCopyWith<_$SignInFormStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/authentication/presentation/bloc/sign_in_form/sign_in_form_event.dart
+++ b/lib/features/authentication/presentation/bloc/sign_in_form/sign_in_form_event.dart
@@ -1,0 +1,10 @@
+part of 'sign_in_form_bloc.dart';
+
+@freezed
+class SignInFormEvent with _$SignInFormEvent {
+  const factory SignInFormEvent.started() = _Started;
+  const factory SignInFormEvent.formSubmitted({
+    required String email,
+    required String password,
+  }) = _FormSubmitted;
+}

--- a/lib/features/authentication/presentation/bloc/sign_in_form/sign_in_form_state.dart
+++ b/lib/features/authentication/presentation/bloc/sign_in_form/sign_in_form_state.dart
@@ -1,0 +1,10 @@
+part of 'sign_in_form_bloc.dart';
+
+@freezed
+class SignInFormState with _$SignInFormState {
+  const factory SignInFormState({
+    @Default(Email.pure()) Email email,
+    @Default(Password.pure()) Password password,
+    bool? isFormValid,
+  }) = _SignInFormState;
+}


### PR DESCRIPTION
### Summary
Added sign-in form validation using BLoC pattern with form state management and "Remember Me" functionality.

### What changed?
- Created new SignInFormBloc to handle form validation logic
- Implemented form state management using Freezed for immutability
- Added validation for email and password fields
- Integrated "Remember Me" functionality to persist user credentials
- Added form submission handling with validation checks

### How to test?
1. Launch the sign-in screen
2. Enter invalid email/password combinations to verify validation
3. Enter valid credentials and verify form submission
4. Enable "Remember Me" and verify credentials persist between app launches
5. Verify error states are properly displayed for invalid inputs

### Why make this change?
To improve the sign-in experience by providing immediate feedback on form validation and adding convenience features like remembered credentials. This helps reduce user friction during authentication while maintaining security through proper validation.