### PR TITLE
Sign up WidgetsBindingObserver

### DIFF
--- a/lib/features/authentication/presentation/screens/signup/signup.dart
+++ b/lib/features/authentication/presentation/screens/signup/signup.dart
@@ -12,8 +12,22 @@ import 'package:mystore/features/authentication/presentation/screens/signup/widg
 import 'package:mystore/core/constants/sizes.dart';
 import 'package:mystore/core/constants/text_strings.dart';
 
-class SignupScreen extends StatelessWidget {
+class SignupScreen extends StatefulWidget {
   const SignupScreen({super.key});
+
+  @override
+  State<SignupScreen> createState() => _SignupScreenState();
+}
+
+class _SignupScreenState extends State<SignupScreen>
+    with WidgetsBindingObserver {
+      
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      context.read<AuthenticationBloc>().add(const AuthenticationEvent.restore());
+    }
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
### Summary
Added app lifecycle state management to the SignupScreen to handle authentication state restoration.

### What changed?
- Converted SignupScreen from StatelessWidget to StatefulWidget
- Implemented WidgetsBindingObserver to monitor app lifecycle changes
- Added logic to restore authentication state when app resumes from background

### How to test?
1. Open the SignupScreen
2. Send the app to background (home button or app switcher)
3. Bring the app back to foreground
4. Verify that authentication state is properly restored

### Why make this change?
To ensure proper authentication state management when users switch between apps or resume the application from background state, preventing potential authentication-related issues during app lifecycle changes.