### PR TITLE
Isar user model to user model

### DIFF
--- a/lib/common/data/models/user_model.dart
+++ b/lib/common/data/models/user_model.dart
@@ -73,3 +73,17 @@ extension UserModelX on UserModel {
     );
   }
 }
+
+extension IsarUserModelX on IsarUserModel {
+  UserModel toUserModel() {
+    return UserModel(
+      id: id,
+      firstName: firstName,
+      lastName: lastName,
+      email: email,
+      username: username,
+      phoneNumber: phoneNumber,
+      photo: photo,
+    );
+  }
+}


### PR DESCRIPTION
### Summary
Added conversion extension from IsarUserModel to UserModel

### What changed?
Added a new extension `IsarUserModelX` that provides a `toUserModel()` method to convert IsarUserModel instances into UserModel objects, mapping all relevant fields including id, firstName, lastName, email, username, phoneNumber, and photo.

### How to test?
1. Create an instance of IsarUserModel with sample data
2. Call `toUserModel()` on the instance
3. Verify that all fields are correctly mapped to the resulting UserModel

### Why make this change?
To provide a clean and type-safe way to convert between Isar database models and domain models, making it easier to maintain separation of concerns between data and domain layers while reducing boilerplate code.