### PR TITLE
Authetication data source and repository

### DIFF
--- a/lib/features/authentication/domain/repositories/authentication_repository.dart
+++ b/lib/features/authentication/domain/repositories/authentication_repository.dart
@@ -15,8 +15,6 @@ abstract class AuthenticationRepository {
 
   Future<(Failure?, void)> logOut();
 
-  Future<(Failure?, User?)> getCurrentUser();
-
   Future<(Failure?, UserEntity?)> signInWithEmailAndPassword({
     required String email,
     required String password,


### PR DESCRIPTION
### Summary
Refactored authentication data source to separate user-related operations and improve Google sign-in flow.

### What changed?
- Renamed `RemoteDataSource` to `AuthRemoteDataSource` for better clarity
- Removed user-specific operations from auth data source
- Modified Google sign-in to return `UserCredential` instead of creating user record
- Removed `getCurrentUser` functionality from auth repository
- Updated repository implementation to use separate data sources for auth and user operations

### How to test?
1. Test email/password sign-up flow
2. Verify Google sign-in functionality
3. Confirm email verification process
4. Test password reset functionality
5. Verify logout operation

### Why make this change?
This change follows the single responsibility principle by separating authentication and user management concerns. The authentication data source now focuses solely on auth operations, while user-related operations are handled by a dedicated user data source, making the code more maintainable and easier to test.