### PR TITLE
Add empty user entity and full name extension to UserEntity

### DIFF
--- a/lib/common/domain/entities/user_entity.dart
+++ b/lib/common/domain/entities/user_entity.dart
@@ -14,6 +14,19 @@ class UserEntity {
     required this.email,
     this.photo,
   });
+
+  static const UserEntity empty = UserEntity(
+    email: '',
+    firstName: '',
+    lastName: '',
+    username: '',
+    phoneNumber: '',
+    photo: null,
+  );
+}
+
+extension UserEntityX on UserEntity {
+  String get fullName => '$firstName $lastName';
 }
 
 class UserAuthCredentials {


### PR DESCRIPTION
### Summary
Added empty user constant and fullName getter to UserEntity

### What changed?
- Added `UserEntity.empty` constant with default empty values
- Created `UserEntityX` extension with `fullName` getter that concatenates first and last name

### How to test?
1. Verify `UserEntity.empty` returns an empty user object
2. Create a UserEntity with first and last name
3. Access `fullName` getter and confirm it returns concatenated name

### Why make this change?
- Provides a standardized empty user state for initialization and reset scenarios
- Simplifies name concatenation logic by encapsulating it in an extension method
- Reduces code duplication when empty user objects are needed