### PR TITLE
Implement UserBloc with events and states for user management

### DIFF
--- a/lib/features/personalization/presentation/bloc/user/user_bloc.dart
+++ b/lib/features/personalization/presentation/bloc/user/user_bloc.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:injectable/injectable.dart';
+import 'package:mystore/common/domain/entities/user_entity.dart';
+import 'package:mystore/common/domain/usecases/manage_user_use_case.dart';
+import 'package:mystore/common/domain/usecases/usecase.dart';
+
+part 'user_event.dart';
+part 'user_state.dart';
+part 'user_bloc.freezed.dart';
+
+@injectable
+class UserBloc extends Bloc<UserEvent, UserState> {
+  final ManageUserUseCase _manageUserUseCase;
+
+  UserBloc(this._manageUserUseCase)
+      : super(const UserState(user: UserEntity.empty)) {
+    on<UserEvent>((event, emit) async {
+      await event.when(
+        getUser: () async {
+          final user = await _manageUserUseCase(const NoParams());
+
+          if (user.$2 != null) {
+            emit(state.copyWith(user: user.$2!));
+          }
+        },
+      );
+    });
+  }
+}

--- a/lib/features/personalization/presentation/bloc/user/user_bloc.freezed.dart
+++ b/lib/features/personalization/presentation/bloc/user/user_bloc.freezed.dart
@@ -1,0 +1,281 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user_bloc.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$UserEvent {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() getUser,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? getUser,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? getUser,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_GetUser value) getUser,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_GetUser value)? getUser,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_GetUser value)? getUser,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $UserEventCopyWith<$Res> {
+  factory $UserEventCopyWith(UserEvent value, $Res Function(UserEvent) then) =
+      _$UserEventCopyWithImpl<$Res, UserEvent>;
+}
+
+/// @nodoc
+class _$UserEventCopyWithImpl<$Res, $Val extends UserEvent>
+    implements $UserEventCopyWith<$Res> {
+  _$UserEventCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$GetUserImplCopyWith<$Res> {
+  factory _$$GetUserImplCopyWith(
+          _$GetUserImpl value, $Res Function(_$GetUserImpl) then) =
+      __$$GetUserImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$GetUserImplCopyWithImpl<$Res>
+    extends _$UserEventCopyWithImpl<$Res, _$GetUserImpl>
+    implements _$$GetUserImplCopyWith<$Res> {
+  __$$GetUserImplCopyWithImpl(
+      _$GetUserImpl _value, $Res Function(_$GetUserImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$GetUserImpl implements _GetUser {
+  const _$GetUserImpl();
+
+  @override
+  String toString() {
+    return 'UserEvent.getUser()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$GetUserImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() getUser,
+  }) {
+    return getUser();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? getUser,
+  }) {
+    return getUser?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? getUser,
+    required TResult orElse(),
+  }) {
+    if (getUser != null) {
+      return getUser();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_GetUser value) getUser,
+  }) {
+    return getUser(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_GetUser value)? getUser,
+  }) {
+    return getUser?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_GetUser value)? getUser,
+    required TResult orElse(),
+  }) {
+    if (getUser != null) {
+      return getUser(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _GetUser implements UserEvent {
+  const factory _GetUser() = _$GetUserImpl;
+}
+
+/// @nodoc
+mixin _$UserState {
+  UserEntity get user => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $UserStateCopyWith<UserState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $UserStateCopyWith<$Res> {
+  factory $UserStateCopyWith(UserState value, $Res Function(UserState) then) =
+      _$UserStateCopyWithImpl<$Res, UserState>;
+  @useResult
+  $Res call({UserEntity user});
+}
+
+/// @nodoc
+class _$UserStateCopyWithImpl<$Res, $Val extends UserState>
+    implements $UserStateCopyWith<$Res> {
+  _$UserStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? user = null,
+  }) {
+    return _then(_value.copyWith(
+      user: null == user
+          ? _value.user
+          : user // ignore: cast_nullable_to_non_nullable
+              as UserEntity,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$UserStateImplCopyWith<$Res>
+    implements $UserStateCopyWith<$Res> {
+  factory _$$UserStateImplCopyWith(
+          _$UserStateImpl value, $Res Function(_$UserStateImpl) then) =
+      __$$UserStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({UserEntity user});
+}
+
+/// @nodoc
+class __$$UserStateImplCopyWithImpl<$Res>
+    extends _$UserStateCopyWithImpl<$Res, _$UserStateImpl>
+    implements _$$UserStateImplCopyWith<$Res> {
+  __$$UserStateImplCopyWithImpl(
+      _$UserStateImpl _value, $Res Function(_$UserStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? user = null,
+  }) {
+    return _then(_$UserStateImpl(
+      user: null == user
+          ? _value.user
+          : user // ignore: cast_nullable_to_non_nullable
+              as UserEntity,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$UserStateImpl implements _UserState {
+  const _$UserStateImpl({this.user = UserEntity.empty});
+
+  @override
+  @JsonKey()
+  final UserEntity user;
+
+  @override
+  String toString() {
+    return 'UserState(user: $user)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UserStateImpl &&
+            (identical(other.user, user) || other.user == user));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, user);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$UserStateImplCopyWith<_$UserStateImpl> get copyWith =>
+      __$$UserStateImplCopyWithImpl<_$UserStateImpl>(this, _$identity);
+}
+
+abstract class _UserState implements UserState {
+  const factory _UserState({final UserEntity user}) = _$UserStateImpl;
+
+  @override
+  UserEntity get user;
+  @override
+  @JsonKey(ignore: true)
+  _$$UserStateImplCopyWith<_$UserStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/personalization/presentation/bloc/user/user_event.dart
+++ b/lib/features/personalization/presentation/bloc/user/user_event.dart
@@ -1,0 +1,6 @@
+part of 'user_bloc.dart';
+
+@freezed
+class UserEvent with _$UserEvent {
+  const factory UserEvent.getUser() = _GetUser;
+}

--- a/lib/features/personalization/presentation/bloc/user/user_state.dart
+++ b/lib/features/personalization/presentation/bloc/user/user_state.dart
@@ -1,0 +1,8 @@
+part of 'user_bloc.dart';
+
+@freezed
+class UserState with _$UserState {
+  const factory UserState({
+    @Default(UserEntity.empty) UserEntity user,
+  }) = _UserState;
+}


### PR DESCRIPTION
### Summary
Added a new UserBloc to manage user state in the personalization feature.

### What changed?
- Created a new UserBloc with associated event and state classes
- Implemented a getUser event handler to fetch and update user data
- Added Freezed-generated code for immutable state management
- Integrated with ManageUserUseCase for user data operations

### How to test?
1. Instantiate UserBloc and verify initial state contains empty UserEntity
2. Dispatch UserEvent.getUser() and confirm state updates with user data
3. Verify error handling when ManageUserUseCase returns null

### Why make this change?
To centralize user state management and provide a clean, predictable way to handle user-related operations in the personalization feature. This implementation follows the BLoC pattern for better separation of concerns and reactive state management.