### PR TITLE
Add ManageUserUseCase and fix parameter naming in RememberMeUseCase

### DIFF
--- a/lib/common/data/repositories/network_info_repository_impl.dart
+++ b/lib/common/data/repositories/network_info_repository_impl.dart
@@ -5,7 +5,7 @@ import 'package:mystore/common/domain/repositories/network_info_repository.dart'
 
 @LazySingleton(as: NetworkInfoRepository)
 class NetworkInfoImpl implements NetworkInfoRepository {
-  InternetConnectionChecker connectionChecker = InternetConnectionChecker();
+  InternetConnectionChecker connectionChecker = InternetConnectionChecker.createInstance();
 
   @override
   Future<(Failure?, bool?)> isConnected() async {

--- a/lib/common/domain/usecases/manage_user_use_case.dart
+++ b/lib/common/domain/usecases/manage_user_use_case.dart
@@ -1,0 +1,17 @@
+import 'package:injectable/injectable.dart';
+import 'package:mystore/common/domain/entities/user_entity.dart';
+import 'package:mystore/common/domain/repositories/user_repository.dart';
+import 'package:mystore/common/domain/usecases/usecase.dart';
+import 'package:mystore/core/error/failures.dart';
+
+@injectable
+class ManageUserUseCase implements UseCase<UserEntity, NoParams> {
+  final UserRepository _userRepository;
+
+  ManageUserUseCase(this._userRepository);
+
+  @override
+  Future<(Failure?, UserEntity?)> call(NoParams params) async {
+    return await _userRepository.getUser();
+  }
+}

--- a/lib/features/authentication/domain/usecase/remember_me_use_case.dart
+++ b/lib/features/authentication/domain/usecase/remember_me_use_case.dart
@@ -5,13 +5,13 @@ import 'package:mystore/common/domain/entities/user_entity.dart';
 import 'package:mystore/features/authentication/domain/repositories/authentication_repository.dart';
 
 @injectable
-class RememberMeUseCase implements UseCase<void, RmemeberMeParams> {
+class RememberMeUseCase implements UseCase<void, RememberMeParams> {
   final AuthenticationRepository repository;
 
   RememberMeUseCase({required this.repository});
 
   @override
-  Future<(Failure?, void)> call(RmemeberMeParams params) async {
+  Future<(Failure?, void)> call(RememberMeParams params) async {
     return await repository.saveCredentials(
         email: params.email, password: params.password);
   }
@@ -25,9 +25,9 @@ class RememberMeUseCase implements UseCase<void, RmemeberMeParams> {
   }
 }
 
-class RmemeberMeParams {
+class RememberMeParams {
   final String email;
   final String password;
 
-  RmemeberMeParams({required this.email, required this.password});
+  RememberMeParams({required this.email, required this.password});
 }


### PR DESCRIPTION
### Summary
Fixed typos in authentication parameters and updated network connection initialization

### What changed?
- Created new `ManageUserUseCase` for handling user entity operations
- Fixed typo in `RememberMeParams` class name (previously `RmemeberMeParams`)
- Updated `NetworkInfoImpl` to use `createInstance()` method for connection checker initialization

### How to test?
1. Verify that remember me functionality works with corrected parameter naming
2. Confirm network connectivity checks are functioning properly
3. Test user management operations through the new use case

### Why make this change?
- Corrects spelling mistakes that could cause confusion in the codebase
- Implements proper initialization pattern for network connectivity checks
- Adds structured user management capabilities through a dedicated use case