### PR TITLE
Integrate UserBloc into NavigationMenu and HomeAppBar; remove unused injection import from LoginForm

### DIFF
--- a/lib/core/common_widgets/widgets/menu/navigation_menu.dart
+++ b/lib/core/common_widgets/widgets/menu/navigation_menu.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:iconsax/iconsax.dart';
 import 'package:mystore/core/constants/colors.dart';
+import 'package:mystore/core/injection/injection_container.dart';
 import 'package:mystore/core/utils/helpers/helper_functions.dart';
+import 'package:mystore/features/personalization/presentation/bloc/user/user_bloc.dart';
 
 class NavigationMenu extends StatefulWidget {
   const NavigationMenu({super.key, required this.child});
@@ -55,7 +58,11 @@ class _NavigationMenuState extends State<NavigationMenu> {
               NavigationDestination(icon: Icon(Iconsax.user), label: 'Profile'),
             ],
           ),
-          body: widget.child,
+          body: BlocProvider(
+            create: (context) =>
+                getIt<UserBloc>()..add(const UserEvent.getUser()),
+            child: widget.child,
+          ),
         );
       },
     );

--- a/lib/features/authentication/presentation/screens/login/widgets/login_form.dart
+++ b/lib/features/authentication/presentation/screens/login/widgets/login_form.dart
@@ -6,7 +6,6 @@ import 'package:iconsax/iconsax.dart';
 
 import 'package:mystore/core/constants/sizes.dart';
 import 'package:mystore/core/constants/text_strings.dart';
-import 'package:mystore/core/injection/injection_container.dart';
 import 'package:mystore/core/inputs/user_inputs.dart';
 import 'package:mystore/core/routing/go_routes.dart';
 import 'package:mystore/features/authentication/presentation/bloc/authentication/authentication_bloc.dart';

--- a/lib/features/authentication/presentation/screens/signup/verify_email.dart
+++ b/lib/features/authentication/presentation/screens/signup/verify_email.dart
@@ -57,6 +57,7 @@ class _VerifyEmailScreenState extends State<VerifyEmailScreen> {
     context
         .read<AuthenticationBloc>()
         .add(AuthenticationEvent.verifyEmail(email: email));
+
     super.initState();
   }
 

--- a/lib/features/shop/screens/home/widgets/home_appbar.dart
+++ b/lib/features/shop/screens/home/widgets/home_appbar.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:go_router/go_router.dart';
+import 'package:mystore/common/domain/entities/user_entity.dart';
 import 'package:mystore/core/common_widgets/widgets/appbar/appbar.dart';
 import 'package:mystore/core/common_widgets/widgets/product/cart/cart_menu_icon.dart';
 
 import 'package:mystore/core/constants/colors.dart';
 import 'package:mystore/core/constants/text_strings.dart';
 import 'package:mystore/core/routing/go_routes.dart';
+import 'package:mystore/features/personalization/presentation/bloc/user/user_bloc.dart';
 
 class HomeAppBar extends StatelessWidget {
   const HomeAppBar({
@@ -15,6 +18,8 @@ class HomeAppBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final bloc = context.watch<UserBloc>();
+
     return MyAppBar(
       title: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -27,7 +32,7 @@ class HomeAppBar extends StatelessWidget {
                 .apply(color: MyColors.grey),
           ),
           Text(
-            MyTexts.homeAppbarSubTitle,
+            bloc.state.user.fullName,
             style: Theme.of(context)
                 .textTheme
                 .headlineSmall!


### PR DESCRIPTION
### Summary
Added user bloc integration to navigation menu and updated home appbar to display user's full name.

### What changed?
- Integrated UserBloc into the NavigationMenu widget to manage user state
- Updated HomeAppBar to display the authenticated user's full name instead of static text
- Removed unused import in login_form.dart
- Added proper user bloc state management in the navigation menu

### How to test?
1. Log in to the application
2. Verify that your full name appears in the home screen's app bar
3. Navigate through different screens to ensure user state persists
4. Verify that the navigation menu continues to function properly

### Why make this change?
To provide a more personalized experience by displaying the user's actual name in the app bar instead of static text, while ensuring proper user state management throughout the navigation flow.